### PR TITLE
Refactor and opimize SharedMemory

### DIFF
--- a/Extensions/ObjectExtensions.cs
+++ b/Extensions/ObjectExtensions.cs
@@ -1,0 +1,12 @@
+﻿namespace ReHUD.Extensions
+{
+    public static class ObjectExtensions
+    {
+        public static bool IsInt(this object value) => value is long
+            || value is ulong
+            || value is int
+            || value is uint
+            || value is short
+            || value is ushort;
+    }
+}

--- a/Extensions/R3eDataExtensions.cs
+++ b/Extensions/R3eDataExtensions.cs
@@ -1,0 +1,10 @@
+﻿using R3E.Data;
+
+namespace ReHUD.Extensions
+{
+    public static class R3eDataExtensions
+    {
+        internal static bool IsNotDriving(this R3eData data) => (data.gameInMenus == 1 || (data.gamePaused == 1 && data.gameInReplay == 0) || data.sessionType == -1);
+        internal static bool IsDriving(this R3eData data) => !data.IsNotDriving();
+    }
+}

--- a/Factories/ProcessObserverFactory.cs
+++ b/Factories/ProcessObserverFactory.cs
@@ -1,0 +1,12 @@
+﻿using ReHUD.Interfaces;
+using ReHUD.Utils;
+
+namespace ReHUD.Factories
+{
+    public class ProcessObserverFactory : IProcessObserverFactory
+    {
+        public IProcessObserver GetObserver(string processName) => new ProcessObserver(new() { processName });
+
+        public IProcessObserver GetObserver(List<string> processNames) => new ProcessObserver(processNames);
+    }
+}

--- a/HudLayout.cs
+++ b/HudLayout.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using ElectronNET.API;
 using ElectronNET.API.Entities;
 using Newtonsoft.Json;
+using ReHUD.Models;
 
 namespace ReHUD;
 

--- a/Interfaces/IProcessObserver.cs
+++ b/Interfaces/IProcessObserver.cs
@@ -1,0 +1,14 @@
+﻿namespace ReHUD.Interfaces
+{
+    public interface IProcessObserver : IDisposable
+    {
+        public event Action OnProcessStarted;
+        public event Action OnProcessStopped;
+
+        public bool IsRunning { get; }
+
+        public void Start();
+
+        public void Stop();
+    }
+}

--- a/Interfaces/IProcessObserverFactory.cs
+++ b/Interfaces/IProcessObserverFactory.cs
@@ -1,0 +1,8 @@
+﻿namespace ReHUD.Interfaces
+{
+    public interface IProcessObserverFactory
+    {
+        IProcessObserver GetObserver(string processName);
+        IProcessObserver GetObserver(List<string> processNames);
+    }
+}

--- a/Interfaces/IR3eDataService.cs
+++ b/Interfaces/IR3eDataService.cs
@@ -1,0 +1,25 @@
+﻿using ElectronNET.API;
+using ReHUD.Models;
+
+namespace ReHUD.Interfaces
+{
+    public interface IR3eDataService : IDisposable
+    {
+        public R3eExtraData Data { get; }
+        public FuelData FuelData { get; }
+        public LapPointsData LapPointsData { get; }
+
+        public BrowserWindow HUDWindow { get; set; }
+        public bool? HUDShown { get; set; }
+        public string[]? UsedKeys { get; set; }
+
+        public void Load();
+        public void Save();
+
+        public void SetEnteredEditMode();
+        public Task SendEmptyData();
+
+        public void SaveBestLap(int layoutId, int classId, double laptime, double[] points, double pointsPerMeter);
+        public string LoadBestLap(int layoutId, int classId);
+    }
+}

--- a/Interfaces/IRaceRoomObserver.cs
+++ b/Interfaces/IRaceRoomObserver.cs
@@ -1,0 +1,6 @@
+﻿namespace ReHUD.Interfaces
+{
+    public interface IRaceRoomObserver : IProcessObserver
+    {
+    }
+}

--- a/Interfaces/IRaceRoomObserver.cs
+++ b/Interfaces/IRaceRoomObserver.cs
@@ -1,6 +1,6 @@
 ﻿namespace ReHUD.Interfaces
 {
-    public interface IRaceRoomObserver : IProcessObserver
+    public interface IRaceRoomObserver : IProcessObserver, IDisposable
     {
     }
 }

--- a/Interfaces/ISharedMemoryService.cs
+++ b/Interfaces/ISharedMemoryService.cs
@@ -1,0 +1,13 @@
+﻿using R3E.Data;
+
+namespace ReHUD.Interfaces
+{
+    public interface ISharedMemoryService : IDisposable
+    {
+        public R3eData? Data { get; }
+        public long FrameRate { get; set; }
+        public bool IsRunning { get; }
+
+        public event Action<R3eData> OnDataReady;
+    }
+}

--- a/Interfaces/IUpdateService.cs
+++ b/Interfaces/IUpdateService.cs
@@ -1,0 +1,9 @@
+﻿namespace ReHUD.Interfaces
+{
+    public interface IUpdateService
+    {
+        public string? AppVersion { get; }
+        public Task<string> GetAppVersion();
+        public Task CheckForUpdates();
+    }
+}

--- a/Models/FuelData.cs
+++ b/Models/FuelData.cs
@@ -8,8 +8,7 @@ public class FuelData : CombinationUserData<FuelCombination>
 
     // combinations[trackLayoutId][carId];
 
-    protected override FuelCombination NewCombinationInstance()
-    {
+    protected override FuelCombination NewCombinationInstance() {
         return new FuelCombination();
     }
 }
@@ -30,48 +29,40 @@ public class FuelCombination
     private double averageLapTime = -1;
     private double lastFuel = -1;
 
-    public void AddFuelUsage(double fuelUsage, bool valid)
-    {
+    public void AddFuelUsage(double fuelUsage, bool valid) {
         if (fuelUsage <= 0)
             return;
 
         lastFuel = fuelUsage;
 
-        if (valid)
-        {
+        if (valid) {
             averageFuelUsage = -1;
             this.fuelUsage.AddLast(fuelUsage);
-            if (this.fuelUsage.Count > MAX_DATA_SIZE)
-            {
+            if (this.fuelUsage.Count > MAX_DATA_SIZE) {
                 this.fuelUsage.RemoveFirst();
             }
         }
     }
-    public void AddFuelUsage(double fuelUsage)
-    {
+    public void AddFuelUsage(double fuelUsage) {
         AddFuelUsage(fuelUsage, true);
     }
 
-    public void AddLapTime(double lapTime)
-    {
+    public void AddLapTime(double lapTime) {
         if (lapTime <= 0)
             return;
 
         averageLapTime = -1;
         lapTimes.AddLast(lapTime);
-        if (lapTimes.Count > MAX_DATA_SIZE)
-        {
+        if (lapTimes.Count > MAX_DATA_SIZE) {
             lapTimes.RemoveFirst();
         }
 
-        if (bestLapTime == -1 || lapTime < bestLapTime)
-        {
+        if (bestLapTime == -1 || lapTime < bestLapTime) {
             bestLapTime = lapTime;
         }
     }
 
-    public double GetAverageFuelUsage()
-    {
+    public double GetAverageFuelUsage() {
         if (averageFuelUsage != -1)
             return averageFuelUsage;
 
@@ -79,24 +70,21 @@ public class FuelCombination
             return -1;
 
         double sum = 0;
-        foreach (double fuel in fuelUsage)
-        {
+        foreach (double fuel in fuelUsage) {
             sum += fuel;
         }
         averageFuelUsage = sum / fuelUsage.Count;
         return averageFuelUsage;
     }
 
-    public double GetLastLapFuelUsage()
-    {
+    public double GetLastLapFuelUsage() {
         if (fuelUsage.Count > 0)
             return lastFuel;
 
         return -1;
     }
 
-    public double GetAverageLapTime()
-    {
+    public double GetAverageLapTime() {
         if (averageLapTime != -1)
             return averageLapTime;
 
@@ -104,16 +92,14 @@ public class FuelCombination
             return -1;
 
         double sum = 0;
-        foreach (double lapTime in lapTimes)
-        {
+        foreach (double lapTime in lapTimes) {
             sum += lapTime;
         }
         averageLapTime = sum / lapTimes.Count;
         return averageLapTime;
     }
 
-    public double GetBestLapTime()
-    {
+    public double GetBestLapTime() {
         return bestLapTime;
     }
 }

--- a/Models/FuelData.cs
+++ b/Models/FuelData.cs
@@ -1,6 +1,6 @@
 using Newtonsoft.Json;
 
-namespace ReHUD;
+namespace ReHUD.Models;
 
 public class FuelData : CombinationUserData<FuelCombination>
 {
@@ -18,7 +18,7 @@ public class FuelData : CombinationUserData<FuelCombination>
 public class FuelCombination
 {
     private const int MAX_DATA_SIZE = 20;
-    
+
     [JsonProperty]
     private readonly LinkedList<double> fuelUsage = new();
     [JsonProperty]

--- a/Models/LapPointsData.cs
+++ b/Models/LapPointsData.cs
@@ -1,6 +1,6 @@
 using Newtonsoft.Json;
 
-namespace ReHUD;
+namespace ReHUD.Models;
 
 public class LapPointsData : CombinationUserData<LapPointsCombination>
 {

--- a/Models/LapPointsData.cs
+++ b/Models/LapPointsData.cs
@@ -8,8 +8,7 @@ public class LapPointsData : CombinationUserData<LapPointsCombination>
 
     // combinations[trackLayoutId][classId];
 
-    protected override LapPointsCombination NewCombinationInstance()
-    {
+    protected override LapPointsCombination NewCombinationInstance() {
         return new LapPointsCombination();
     }
 }
@@ -23,10 +22,8 @@ public class LapPointsCombination
     [JsonProperty]
     private double? pointsPerMeter;
 
-    public void Set(double bestLapTime, double[] lapPoints, double pointsPerMeter)
-    {
-        if (this.bestLapTime == null || this.bestLapTime > bestLapTime)
-        {
+    public void Set(double bestLapTime, double[] lapPoints, double pointsPerMeter) {
+        if (this.bestLapTime == null || this.bestLapTime > bestLapTime) {
             this.bestLapTime = bestLapTime;
             this.lapPoints = lapPoints;
             this.pointsPerMeter = pointsPerMeter;
@@ -34,10 +31,8 @@ public class LapPointsCombination
         }
     }
 
-    public string Serialize()
-    {
-        return JsonConvert.SerializeObject(new
-        {
+    public string Serialize() {
+        return JsonConvert.SerializeObject(new {
             bestLapTime,
             lapPoints,
             pointsPerMeter

--- a/Models/R3E.cs
+++ b/Models/R3E.cs
@@ -204,7 +204,7 @@ namespace R3E
     namespace Data
     {
         [StructLayout(LayoutKind.Sequential, Pack = 1)]
-        internal struct RaceDuration<T>
+        public struct RaceDuration<T>
         {
             public T race1;
             public T race2;
@@ -212,7 +212,7 @@ namespace R3E
         }
 
         [StructLayout(LayoutKind.Sequential, Pack = 1)]
-        internal struct Vector3<T>
+        public struct Vector3<T>
         {
             public T x;
             public T y;
@@ -220,7 +220,7 @@ namespace R3E
         }
 
         [StructLayout(LayoutKind.Sequential, Pack = 1)]
-        internal struct Orientation<T>
+        public struct Orientation<T>
         {
             public T pitch;
             public T yaw;
@@ -228,7 +228,7 @@ namespace R3E
         }
 
         [StructLayout(LayoutKind.Sequential, Pack = 1)]
-        internal struct SectorStarts<T>
+        public struct SectorStarts<T>
         {
             public T sector1;
             public T sector2;
@@ -236,7 +236,7 @@ namespace R3E
         }
 
         [StructLayout(LayoutKind.Sequential, Pack = 1)]
-        internal struct PlayerData
+        public struct PlayerData
         {
             // Virtual physics time
             // Unit: Ticks (1 tick = 1/400th of a second)
@@ -322,7 +322,7 @@ namespace R3E
         }
 
         [StructLayout(LayoutKind.Sequential, Pack = 1)]
-        internal struct Flags
+        public struct Flags
         {
             // Whether yellow flag is currently active
             // -1 = no data
@@ -396,7 +396,7 @@ namespace R3E
         }
 
         [StructLayout(LayoutKind.Sequential, Pack = 1)]
-        internal struct CarDamage
+        public struct CarDamage
         {
             // Range: 0.0 - 1.0
             // Note: -1.0 = N/A
@@ -421,7 +421,7 @@ namespace R3E
         }
 
         [StructLayout(LayoutKind.Sequential, Pack = 1)]
-        internal struct TireData<T>
+        public struct TireData<T>
         {
             public T frontLeft;
             public T frontRight;
@@ -430,7 +430,7 @@ namespace R3E
         }
 
         [StructLayout(LayoutKind.Sequential, Pack = 1)]
-        internal struct PitMenuState
+        public struct PitMenuState
         {
             // Pit menu preset
             public Int32 preset;
@@ -451,7 +451,7 @@ namespace R3E
         }
 
         [StructLayout(LayoutKind.Sequential, Pack = 1)]
-        internal struct CutTrackPenalties
+        public struct CutTrackPenalties
         {
             public Int32 driveThrough;
             public Int32 stopAndGo;
@@ -461,7 +461,7 @@ namespace R3E
         }
 
         [StructLayout(LayoutKind.Sequential, Pack = 1)]
-        internal struct DRS
+        public struct DRS
         {
             // If DRS is equipped and allowed
             // 0 = No, 1 = Yes, -1 = N/A
@@ -479,7 +479,7 @@ namespace R3E
         }
 
         [StructLayout(LayoutKind.Sequential, Pack = 1)]
-        internal struct PushToPass
+        public struct PushToPass
         {
             public Int32 available;
             public Int32 engaged;
@@ -489,7 +489,7 @@ namespace R3E
         }
 
         [StructLayout(LayoutKind.Sequential, Pack = 1)]
-        internal struct TireTempInformation
+        public struct TireTempInformation
         {
             public TireTemperature<Single> currentTemp;
             public Single optimalTemp;
@@ -498,7 +498,7 @@ namespace R3E
         }
 
         [StructLayout(LayoutKind.Sequential, Pack = 1)]
-        internal struct BrakeTemp
+        public struct BrakeTemp
         {
             public Single currentTemp;
             public Single optimalTemp;
@@ -507,7 +507,7 @@ namespace R3E
         }
 
         [StructLayout(LayoutKind.Sequential, Pack = 1)]
-        internal struct TireTemperature<T>
+        public struct TireTemperature<T>
         {
             public T left;
             public T center;
@@ -515,7 +515,7 @@ namespace R3E
         }
 
         [StructLayout(LayoutKind.Sequential, Pack = 1)]
-        internal struct AidSettings
+        public struct AidSettings
         {
             // ABS; -1 = N/A, 0 = off, 1 = on, 5 = currently active
             public Int32 abs;
@@ -530,7 +530,7 @@ namespace R3E
         }
 
         [StructLayout(LayoutKind.Sequential, Pack = 1)]
-        internal struct Sectors<T>
+        public struct Sectors<T>
         {
             public T sector1;
             public T sector2;
@@ -538,7 +538,7 @@ namespace R3E
         }
 
         [StructLayout(LayoutKind.Sequential, Pack = 1)]
-        internal struct DriverInfo
+        public struct DriverInfo
         {
             [MarshalAs(UnmanagedType.ByValArray, SizeConst = 64)]
             public byte[] name; // UTF-8
@@ -558,7 +558,7 @@ namespace R3E
         }
 
         [StructLayout(LayoutKind.Sequential, Pack = 1)]
-        internal struct DriverData
+        public struct DriverData
         {
             public DriverInfo driverInfo;
             // Note: See the R3E.Constant.FinishStatus enum
@@ -664,7 +664,7 @@ namespace R3E
         }
 
         [StructLayout(LayoutKind.Sequential, Pack = 1)]
-        internal struct Shared
+        public struct R3eData
         {
             //////////////////////////////////////////////////////////////////////////
             // Version

--- a/Models/R3E.cs
+++ b/Models/R3E.cs
@@ -654,7 +654,7 @@ namespace R3E
             // DisqualifyPenaltyIgnoredBlueFlag = 13,
             // DisqualifyPenaltyMax = 14
             public Int32 penaltyReason;
-	
+
             // -1 unavailable, 0 = ignition off, 1 = ignition on but not running, 2 = ignition on and running
             public Int32 engineState;
 
@@ -729,7 +729,7 @@ namespace R3E
 
             // If the session is time based, lap based or time based with an extra lap at the end
             public Int32 sessionLengthFormat;
- 
+
             // Unit: Meter per second (m/s)
             public Single sessionPitSpeedLimit;
 
@@ -1048,7 +1048,7 @@ namespace R3E
             public Int32 tireTypeRear;
             // Which subtype of tires the car has
             // Note: See the R3E.Constant.TireSubtype enum
-			public Int32 tireSubtypeFront;
+            public Int32 tireSubtypeFront;
             public Int32 tireSubtypeRear;
 
             // Current brake temperature (-1.0 = N/A)

--- a/Models/R3eExtraData.cs
+++ b/Models/R3eExtraData.cs
@@ -1,9 +1,11 @@
 using Newtonsoft.Json.Linq;
+using R3E.Data;
 
-namespace ReHUD;
+namespace ReHUD.Models;
 
-internal struct ExtraData {
-    public R3E.Data.Shared rawData;
+public struct R3eExtraData
+{
+    public R3eData rawData;
 
     // difference to RawData.FuelPerLap is that it averages instead of taking the maximum, and is also based on data from previous sessions.
     public double fuelPerLap;
@@ -21,22 +23,31 @@ internal struct ExtraData {
     /// Serialize this object to JSON.
     /// </summary>
     /// <param name="filter">If not null, only include these keys in the output. Keys starting with '+' are keys from ExtraData, other keys are from the rawData field.</param>
-    public readonly string Serialize(string[]? filter = null) {
+    public readonly string Serialize(string[]? filter = null)
+    {
         var obj = JObject.FromObject(this);
-        
-        if (filter != null) {
+
+        if (filter != null)
+        {
             var newObj = new JObject
             {
                 ["rawData"] = new JObject()
             };
-            foreach (var key in filter) {
-                try {
-                    if (key.StartsWith('+')) {
+            foreach (var key in filter)
+            {
+                try
+                {
+                    if (key.StartsWith('+'))
+                    {
                         newObj[key[1..]] = obj[key[1..]];
-                    } else {
+                    }
+                    else
+                    {
                         newObj["rawData"]![key] = obj["rawData"]![key];
                     }
-                } catch (Exception e) {
+                }
+                catch (Exception e)
+                {
                     Startup.logger.Error($"Failed to serialize shared memory key '{key}': {e}");
                     throw;
                 }

--- a/Models/R3eExtraData.cs
+++ b/Models/R3eExtraData.cs
@@ -23,31 +23,23 @@ public struct R3eExtraData
     /// Serialize this object to JSON.
     /// </summary>
     /// <param name="filter">If not null, only include these keys in the output. Keys starting with '+' are keys from ExtraData, other keys are from the rawData field.</param>
-    public readonly string Serialize(string[]? filter = null)
-    {
+    public readonly string Serialize(string[]? filter = null) {
         var obj = JObject.FromObject(this);
 
-        if (filter != null)
-        {
-            var newObj = new JObject
-            {
+        if (filter != null) {
+            var newObj = new JObject {
                 ["rawData"] = new JObject()
             };
-            foreach (var key in filter)
-            {
-                try
-                {
-                    if (key.StartsWith('+'))
-                    {
+            foreach (var key in filter) {
+                try {
+                    if (key.StartsWith('+')) {
                         newObj[key[1..]] = obj[key[1..]];
                     }
-                    else
-                    {
+                    else {
                         newObj["rawData"]![key] = obj["rawData"]![key];
                     }
                 }
-                catch (Exception e)
-                {
+                catch (Exception e) {
                     Startup.logger.Error($"Failed to serialize shared memory key '{key}': {e}");
                     throw;
                 }

--- a/Models/Settings.cs
+++ b/Models/Settings.cs
@@ -1,7 +1,7 @@
 using System.Collections.Immutable;
 using Newtonsoft.Json;
 
-namespace ReHUD;
+namespace ReHUD.Models;
 
 public class Settings : JsonUserData
 {
@@ -21,10 +21,7 @@ public class Settings : JsonUserData
         settings = new SettingsData(data);
     }
 
-    public override string Serialize()
-    {
-        return settings.Serialize();
-    }
+    public override string Serialize() => settings.Serialize();
 }
 
 [JsonObject(MemberSerialization.OptIn)]
@@ -48,7 +45,8 @@ public class SettingsData
 
     public IEnumerable<KeyValuePair<string, object>> Settings => settings;
 
-    public SettingsData() {
+    public SettingsData()
+    {
         settings = new();
     }
     public SettingsData(string data)
@@ -81,7 +79,7 @@ public class SettingsData
 
     public object? Get(string key)
     {
-        return Contains(key) ? settings[key] : (DefaultSettings.ContainsKey(key) ? DefaultSettings[key] : null);
+        return Contains(key) ? settings[key] : DefaultSettings.ContainsKey(key) ? DefaultSettings[key] : null;
     }
 
     public object? Get(string key, object? orDefault)

--- a/Models/Settings.cs
+++ b/Models/Settings.cs
@@ -1,5 +1,5 @@
-using System.Collections.Immutable;
 using Newtonsoft.Json;
+using System.Collections.Immutable;
 
 namespace ReHUD.Models;
 
@@ -11,10 +11,8 @@ public class Settings : JsonUserData
 
     public SettingsData Data => settings;
 
-    protected override void Load(string? data)
-    {
-        if (data == null)
-        {
+    protected override void Load(string? data) {
+        if (data == null) {
             settings = new SettingsData();
             return;
         }
@@ -45,31 +43,24 @@ public class SettingsData
 
     public IEnumerable<KeyValuePair<string, object>> Settings => settings;
 
-    public SettingsData()
-    {
+    public SettingsData() {
         settings = new();
     }
-    public SettingsData(string data)
-    {
+    public SettingsData(string data) {
         settings = JsonConvert.DeserializeObject<Dictionary<string, object>>(data) ?? new();
-        foreach (var (key, value) in DefaultSettings)
-        {
-            if (!settings.ContainsKey(key))
-            {
+        foreach (var (key, value) in DefaultSettings) {
+            if (!settings.ContainsKey(key)) {
                 settings[key] = value;
             }
         }
     }
 
-    public string Serialize()
-    {
+    public string Serialize() {
         return JsonConvert.SerializeObject(settings);
     }
 
-    public void Set(string? key, object value)
-    {
-        if (key == null)
-        {
+    public void Set(string? key, object value) {
+        if (key == null) {
             Startup.logger.Error("Attempted to set null key in settings. Value: " + value.ToString());
             return;
         }
@@ -77,25 +68,21 @@ public class SettingsData
         settings[key] = value;
     }
 
-    public object? Get(string key)
-    {
+    public object? Get(string key) {
         return Contains(key) ? settings[key] : DefaultSettings.ContainsKey(key) ? DefaultSettings[key] : null;
     }
 
-    public object? Get(string key, object? orDefault)
-    {
+    public object? Get(string key, object? orDefault) {
         return Contains(key) ? settings[key] : orDefault;
     }
 
-    public object? Remove(string key)
-    {
+    public object? Remove(string key) {
         var value = Get(key);
         settings.Remove(key);
         return value;
     }
 
-    public bool Contains(string key)
-    {
+    public bool Contains(string key) {
         return settings.ContainsKey(key);
     }
 }
@@ -107,8 +94,7 @@ public class HudLayoutSettingsEntry
     public readonly string id;
     public bool active { get; set; }
 
-    public HudLayoutSettingsEntry(string id, bool active)
-    {
+    public HudLayoutSettingsEntry(string id, bool active) {
         this.id = id;
         this.active = active;
     }

--- a/Models/UserData.cs
+++ b/Models/UserData.cs
@@ -1,8 +1,9 @@
 using Newtonsoft.Json;
 
-namespace ReHUD;
+namespace ReHUD.Models;
 
-public abstract class UserData {
+public abstract class UserData
+{
     public static readonly string dataPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "ReHUD");
 
     public virtual string SubPath { get; } = "";
@@ -26,11 +27,15 @@ public abstract class UserData {
         WriteDataFile(DataFilePath, Serialize());
     }
 
-    public virtual bool Delete() {
-        try {
+    public virtual bool Delete()
+    {
+        try
+        {
             File.Delete(PathTo(DataFilePath));
             return true;
-        } catch (Exception e) {
+        }
+        catch (Exception e)
+        {
             Startup.logger.Error($"Failed to delete file {DataFilePath}: {e}");
             return false;
         }
@@ -80,7 +85,7 @@ public abstract class CombinationUserData<C> : JsonUserData
     [JsonProperty]
     protected Dictionary<int, Dictionary<int, C>> combinations;
 
-    protected CombinationUserData() : this(new Dictionary<int, Dictionary<int, C>>()){  }
+    protected CombinationUserData() : this(new Dictionary<int, Dictionary<int, C>>()) { }
     protected CombinationUserData(Dictionary<int, Dictionary<int, C>> combinations)
     {
         this.combinations = combinations;

--- a/Models/UserData.cs
+++ b/Models/UserData.cs
@@ -14,54 +14,44 @@ public abstract class UserData
 
     public bool DidLoad { get; private set; } = false;
 
-    public void Load()
-    {
+    public void Load() {
         DidLoad = true;
         Load(ReadDataFile(DataFilePath));
     }
 
     protected abstract void Load(string? data);
 
-    public virtual void Save()
-    {
+    public virtual void Save() {
         WriteDataFile(DataFilePath, Serialize());
     }
 
-    public virtual bool Delete()
-    {
-        try
-        {
+    public virtual bool Delete() {
+        try {
             File.Delete(PathTo(DataFilePath));
             return true;
         }
-        catch (Exception e)
-        {
+        catch (Exception e) {
             Startup.logger.Error($"Failed to delete file {DataFilePath}: {e}");
             return false;
         }
     }
 
-    public string PathTo(string name)
-    {
+    public string PathTo(string name) {
         return Path.Combine(dataPath, SubPath, name);
     }
 
-    private string? ReadDataFile(string name)
-    {
-        try
-        {
+    private string? ReadDataFile(string name) {
+        try {
             var path = PathTo(name);
             Directory.CreateDirectory(Path.GetDirectoryName(path)!);
             return File.ReadAllText(path);
         }
-        catch
-        {
+        catch {
             return DEFAULT_WHEN_EMPTY;
         }
     }
 
-    private void WriteDataFile(string name, string data)
-    {
+    private void WriteDataFile(string name, string data) {
         File.WriteAllText(PathTo(name), data);
     }
 }
@@ -70,8 +60,7 @@ public abstract class UserData
 public abstract class JsonUserData : UserData
 {
     protected override string DEFAULT_WHEN_EMPTY => "{}";
-    public override string Serialize()
-    {
+    public override string Serialize() {
         return JsonConvert.SerializeObject(this);
     }
 }
@@ -86,27 +75,21 @@ public abstract class CombinationUserData<C> : JsonUserData
     protected Dictionary<int, Dictionary<int, C>> combinations;
 
     protected CombinationUserData() : this(new Dictionary<int, Dictionary<int, C>>()) { }
-    protected CombinationUserData(Dictionary<int, Dictionary<int, C>> combinations)
-    {
+    protected CombinationUserData(Dictionary<int, Dictionary<int, C>> combinations) {
         this.combinations = combinations;
     }
 
-    public C? GetCombination(int id1, int id2, bool createIfMissing)
-    {
-        if (!combinations.ContainsKey(id1))
-        {
-            if (!createIfMissing)
-            {
+    public C? GetCombination(int id1, int id2, bool createIfMissing) {
+        if (!combinations.ContainsKey(id1)) {
+            if (!createIfMissing) {
                 return default;
             }
             combinations.Add(id1, new Dictionary<int, C>());
         }
 
         Dictionary<int, C> layoutCombos = combinations[id1];
-        if (!layoutCombos.ContainsKey(id2))
-        {
-            if (!createIfMissing)
-            {
+        if (!layoutCombos.ContainsKey(id2)) {
+            if (!createIfMissing) {
                 return default;
             }
             layoutCombos.Add(id2, NewCombinationInstance());
@@ -115,35 +98,28 @@ public abstract class CombinationUserData<C> : JsonUserData
         return layoutCombos[id2];
     }
 
-    public C GetCombination(int id1, int id2)
-    {
+    public C GetCombination(int id1, int id2) {
         return GetCombination(id1, id2, true)!;
     }
 
-    public C SetCombination(int id1, int id2, C combination)
-    {
-        if (!combinations.ContainsKey(id1))
-        {
+    public C SetCombination(int id1, int id2, C combination) {
+        if (!combinations.ContainsKey(id1)) {
             combinations.Add(id1, new Dictionary<int, C>());
         }
 
         Dictionary<int, C> layoutCombos = combinations[id1];
-        if (!layoutCombos.ContainsKey(id2))
-        {
+        if (!layoutCombos.ContainsKey(id2)) {
             layoutCombos.Add(id2, combination);
         }
-        else
-        {
+        else {
             layoutCombos[id2] = combination;
         }
 
         return combination;
     }
 
-    protected override void Load(string? data)
-    {
-        if (data == null)
-        {
+    protected override void Load(string? data) {
+        if (data == null) {
             combinations = new Dictionary<int, Dictionary<int, C>>();
             return;
         }
@@ -157,8 +133,7 @@ public abstract class CombinationUserData<C> : JsonUserData
             combinations = loadedData.combinations;
     }
 
-    public void Clear()
-    {
+    public void Clear() {
         combinations.Clear();
     }
 }

--- a/Pages/Settings.cshtml
+++ b/Pages/Settings.cshtml
@@ -31,6 +31,8 @@
         }
     </choice-setting>
 
+    <toggle-setting key="enableVRMode" restart-to-apply="false" tooltip="Renders ReHUD with a black background for proper mirroring into SteamVR">Enable VR Mode</toggle-setting>
+
     <slider-setting key="framerate" min="3" max="1000" step="1" value="60">Framerate</slider-setting>
 
     <choice-setting key="speedUnits" value="kmh">

--- a/ProcessObserver.cs
+++ b/ProcessObserver.cs
@@ -1,0 +1,79 @@
+﻿using System.Diagnostics;
+using System.Management;
+
+namespace ReHUD
+{
+    public class ProcessObserver : IDisposable
+    {
+        private readonly List<string> processNames;
+        private readonly ManagementEventWatcher startWatcher;
+        private readonly ManagementEventWatcher stopWatcher;
+
+        public event Action OnProcessStarted;
+        public event Action OnProcessStopped;
+
+        public bool IsRunning { get => processNames.Any(processName => Process.GetProcessesByName(processName).Length > 0); }
+
+        public ProcessObserver(List<string> processNames)
+        {
+            Startup.logger.Info($"Creating process observer for {processNames.Count} process names: {string.Join(", ", processNames)}");
+
+            this.processNames = processNames;
+
+            var processNamePredicate = string.Join(" OR ", processNames.Select(processName => $"TargetInstance.Name = '{processName}'"));
+            startWatcher = new ManagementEventWatcher(new WqlEventQuery($"SELECT * FROM __InstanceCreationEvent WITHIN 1 WHERE TargetInstance ISA 'Win32_Process' AND ({processNamePredicate})"));
+            startWatcher.EventArrived += ProcessStarted;
+
+            stopWatcher = new ManagementEventWatcher(new WqlEventQuery("SELECT * FROM __InstanceDeletionEvent WITHIN 1 WHERE TargetInstance ISA 'Win32_Process' AND (TargetInstance.Name = 'RRRE.exe' OR TargetInstance.Name = 'RRRE64.exe')"));
+            stopWatcher.EventArrived += ProcessStopped;
+        }
+
+        private void ProcessStarted(object sender, EventArrivedEventArgs e)
+        {
+            Startup.logger.Info($"Got process start event for processes: {string.Join(", ", processNames)}");
+            OnProcessStarted?.Invoke();
+        }
+        private void ProcessStopped(object sender, EventArrivedEventArgs e)
+        {
+            Startup.logger.Info($"Got process stop event for processes: {String.Join(", ", processNames)}");
+            OnProcessStopped?.Invoke();
+        }
+
+        public void Start()
+        {
+            Startup.logger.Info("Start Called on Process Observer");
+
+            startWatcher.Start();
+            stopWatcher.Start();
+
+            if (IsRunning)
+            {
+                Startup.logger.Info("Process is already running when Start called, emitting OnProcessStarted event");
+                OnProcessStarted?.Invoke();
+            }
+            else
+            {
+                Startup.logger.Info("Process is not yet running when Start called, waiting for WMI event");
+            }
+        }
+
+        public void Stop()
+        {
+            Startup.logger.Info("Stop Called on Process Observer");
+
+            startWatcher.Stop();
+            stopWatcher.Stop();
+        }
+
+        public void Dispose()
+        {
+            Startup.logger.Info("Disposing Process Observer");
+
+            startWatcher.Stop();
+            stopWatcher.Stop();
+
+            startWatcher.Dispose();
+            stopWatcher.Dispose();
+        }
+    }
+}

--- a/ProcessObserver.cs
+++ b/ProcessObserver.cs
@@ -20,7 +20,8 @@ namespace ReHUD
 
             this.processNames = processNames;
 
-            var processNamePredicate = string.Join(" OR ", processNames.Select(processName => $"TargetInstance.Name = '{processName}'"));
+            var processNamePredicate = string.Join(" OR ", processNames.Select(processName => $"TargetInstance.Name = '{processName}.exe'"));
+
             startWatcher = new ManagementEventWatcher(new WqlEventQuery($"SELECT * FROM __InstanceCreationEvent WITHIN 1 WHERE TargetInstance ISA 'Win32_Process' AND ({processNamePredicate})"));
             startWatcher.EventArrived += ProcessStarted;
 

--- a/Program.cs
+++ b/Program.cs
@@ -14,7 +14,9 @@ public static class Program
             .ConfigureWebHostDefaults(webBuilder =>
             {
                 webBuilder.UseElectron(args);
-                // webBuilder.UseEnvironment(Environments.Development);
+//#if (DEBUG)
+//                webBuilder.UseEnvironment(Environments.Development);
+//# endif
                 webBuilder.UseStartup<Startup>();
             });
 }

--- a/Program.cs
+++ b/Program.cs
@@ -1,21 +1,22 @@
 using ElectronNET.API;
+using ReHUD.Factories;
+using ReHUD.Interfaces;
+using ReHUD.Services;
+using ReHUD.Utils;
 using System.Diagnostics;
 
 namespace ReHUD;
 
 public static class Program
 {
-    public static void Main(string[] args)
-    {
+    public static void Main(string[] args) {
 #if DEBUG
         Debugger.Launch();
 #endif
-        try
-        {
+        try {
             CreateWebHostBuilder(args).Build().Run();
         }
-        catch (Exception ex)
-        {
+        catch (Exception ex) {
             Console.WriteLine($"An error occurred: {ex.Message}");
             Console.WriteLine(ex.StackTrace);
         }
@@ -23,16 +24,14 @@ public static class Program
 
     public static IHostBuilder CreateWebHostBuilder(string[] args) =>
         Host.CreateDefaultBuilder(args)
-            .ConfigureWebHostDefaults(webBuilder =>
-            {
+            .ConfigureWebHostDefaults(webBuilder => {
                 Console.WriteLine("Configuring Web Host Defaults");
                 webBuilder.UseElectron(args);
 #if DEBUG
                 webBuilder.UseEnvironment(Environments.Development);
 #endif
                 webBuilder.UseStartup<Startup>();
-            }).ConfigureLogging((hostingContext, logging) =>
-            {
+            }).ConfigureLogging((hostingContext, logging) => {
                 logging.ClearProviders();
                 logging.AddConsole();
                 logging.AddDebug();
@@ -40,5 +39,14 @@ public static class Program
                 logging.AddFilter("Microsoft", LogLevel.Warning)
                         .AddFilter("System", LogLevel.Warning)
                         .AddFilter("LoggingConsoleApp.Program", LogLevel.Debug);
+            }).ConfigureServices(services => {
+                services.AddLogging();
+                services.AddSignalR();
+                services.AddRazorPages();
+                services.AddSingleton<IProcessObserverFactory, ProcessObserverFactory>();
+                services.AddSingleton<IRaceRoomObserver, RaceRoomObserver>();
+                services.AddSingleton<ISharedMemoryService, SharedMemoryService>();
+                services.AddSingleton<IR3eDataService, R3eDataService>();
+                services.AddSingleton<IUpdateService, UpdateService>();
             });
 }

--- a/Program.cs
+++ b/Program.cs
@@ -1,4 +1,5 @@
 using ElectronNET.API;
+using System.Diagnostics;
 
 namespace ReHUD;
 
@@ -6,17 +7,38 @@ public static class Program
 {
     public static void Main(string[] args)
     {
-        CreateWebHostBuilder(args).Build().Run();
+#if DEBUG
+        Debugger.Launch();
+#endif
+        try
+        {
+            CreateWebHostBuilder(args).Build().Run();
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"An error occurred: {ex.Message}");
+            Console.WriteLine(ex.StackTrace);
+        }
     }
 
     public static IHostBuilder CreateWebHostBuilder(string[] args) =>
         Host.CreateDefaultBuilder(args)
             .ConfigureWebHostDefaults(webBuilder =>
             {
+                Console.WriteLine("Configuring Web Host Defaults");
                 webBuilder.UseElectron(args);
-#if (DEBUG)
+#if DEBUG
                 webBuilder.UseEnvironment(Environments.Development);
-# endif
+#endif
                 webBuilder.UseStartup<Startup>();
+            }).ConfigureLogging((hostingContext, logging) =>
+            {
+                logging.ClearProviders();
+                logging.AddConsole();
+                logging.AddDebug();
+                logging.AddEventSourceLogger();
+                logging.AddFilter("Microsoft", LogLevel.Warning)
+                        .AddFilter("System", LogLevel.Warning)
+                        .AddFilter("LoggingConsoleApp.Program", LogLevel.Debug);
             });
 }

--- a/Program.cs
+++ b/Program.cs
@@ -14,9 +14,9 @@ public static class Program
             .ConfigureWebHostDefaults(webBuilder =>
             {
                 webBuilder.UseElectron(args);
-//#if (DEBUG)
-//                webBuilder.UseEnvironment(Environments.Development);
-//# endif
+#if (DEBUG)
+                webBuilder.UseEnvironment(Environments.Development);
+# endif
                 webBuilder.UseStartup<Startup>();
             });
 }

--- a/Properties/launchSettings.json
+++ b/Properties/launchSettings.json
@@ -1,37 +1,28 @@
 {
-  "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "http://localhost:8612",
-      "sslPort": 44384
-    }
-  },
   "profiles": {
     "Electron.NET App": {
       "commandName": "Executable",
       "executablePath": "electronize",
-      "commandLineArgs": "start",
+      "commandLineArgs": "start /args --inspect=9090",
       "workingDirectory": "."
     },
-
     "http": {
       "commandName": "Project",
-      "dotnetRunMessages": true,
       "launchBrowser": true,
-      "applicationUrl": "http://localhost:5093",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
-      }
+      },
+      "dotnetRunMessages": true,
+      "applicationUrl": "http://localhost:5093"
     },
     "https": {
       "commandName": "Project",
-      "dotnetRunMessages": true,
       "launchBrowser": true,
-      "applicationUrl": "https://localhost:7041;http://localhost:5093",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
-      }
+      },
+      "dotnetRunMessages": true,
+      "applicationUrl": "https://localhost:7041;http://localhost:5093"
     },
     "IIS Express": {
       "commandName": "IISExpress",
@@ -39,6 +30,14 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
+    }
+  },
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:8612",
+      "sslPort": 44384
     }
   }
 }

--- a/ReHUD.csproj
+++ b/ReHUD.csproj
@@ -4,6 +4,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>ReHUD</RootNamespace>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ReHUD.csproj
+++ b/ReHUD.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ElectronNET.API" Version="99.0.6" />
+    <PackageReference Include="ElectronNET.API" Version="99.0.8" />
     <PackageReference Include="log4net" Version="2.0.15" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>

--- a/ReHUD.csproj
+++ b/ReHUD.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="ElectronNET.API" Version="99.0.8" />
     <PackageReference Include="log4net" Version="2.0.15" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="PrecisionTimer.NET" Version="2.4.0.3" />
     <PackageReference Include="System.Management" Version="8.0.0" />
   </ItemGroup>
 

--- a/ReHUD.csproj
+++ b/ReHUD.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="ElectronNET.API" Version="99.0.8" />
     <PackageReference Include="log4net" Version="2.0.15" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="System.Management" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ReHUD.csproj
+++ b/ReHUD.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>ReHUD</RootNamespace>

--- a/ReHUDHub.cs
+++ b/ReHUDHub.cs
@@ -33,16 +33,5 @@ namespace SignalRChat.Hubs
                 Console.WriteLine(e);
             }
         }
-
-        public void SaveBestLap(int layoutId, int classId, double laptime, double[] points, double pointsPerMeter)
-        {
-            Startup.logger.Info($"SaveBestLap: layoutId={layoutId}, classId={classId}, laptime={laptime}, points={points.Length}, pointsPerMeter={pointsPerMeter}");
-            Startup.SaveBestLap(layoutId, classId, laptime, points, pointsPerMeter);
-        }
-
-        public string LoadBestLap(int layoutId, int classId)
-        {
-            return Startup.LoadBestLap(layoutId, classId);
-        }
     }
 }

--- a/ReHUDHub.cs
+++ b/ReHUDHub.cs
@@ -5,8 +5,7 @@ namespace SignalRChat.Hubs
 {
     public class ReHUDHub : Hub
     {
-        public void Log(string level, double startTimestamp, double endTimestamp, string message)
-        {
+        public void Log(string level, double startTimestamp, double endTimestamp, string message) {
             try {
                 if (startTimestamp != -1) {
                     startTimestamp /= 1000;
@@ -29,7 +28,8 @@ namespace SignalRChat.Hubs
                             break;
                     }
                 }
-            } catch (Exception e) {
+            }
+            catch (Exception e) {
                 Console.WriteLine(e);
             }
         }

--- a/ReHUDVersion.cs
+++ b/ReHUDVersion.cs
@@ -10,13 +10,11 @@ public class ReHUDVersion : UserData
     protected override string DataFilePath => "ReHUD.version";
     private Version version = DEFAULT_VERSION;
 
-    public override string Serialize()
-    {
+    public override string Serialize() {
         return version.ToString();
     }
 
-    protected override void Load(string? data)
-    {
+    protected override void Load(string? data) {
         version = TrimVersion(data);
     }
 
@@ -36,14 +34,11 @@ public class ReHUDVersion : UserData
         Save();
     }
 
-    private static void OnVersionChanged(Version previousVersion, Version version)
-    {
+    private static void OnVersionChanged(Version previousVersion, Version version) {
         Startup.logger.Info($"Upgrading ReHUD from v{previousVersion} to v{version}");
         var matchingActions = UpgradeActions.Where(x => x.Item1 > previousVersion && x.Item1 <= version);
-        foreach (var versionActions in matchingActions)
-        {
-            foreach (var action in versionActions.Item2)
-            {
+        foreach (var versionActions in matchingActions) {
+            foreach (var action in versionActions.Item2) {
                 Startup.logger.Info($"Running upgrade action v{versionActions.Item1}: {action.Item1}");
                 action.Item2();
             }
@@ -63,7 +58,7 @@ public class ReHUDVersion : UserData
                         Startup.logger.Info("Found HUD layout in settings, moving to separate file");
 
                         HudLayout hudLayoutData = HudLayout.AddHudLayout(new(true));
-                        
+
                         foreach (var element in hudLayout) {
                             if (element.Value is JArray elementData) {
                                 var id = element.Key;
@@ -85,8 +80,7 @@ public class ReHUDVersion : UserData
         }),
     };
 
-    public static Version TrimVersion(string? version)
-    {
+    public static Version TrimVersion(string? version) {
         if (version == null) return DEFAULT_VERSION;
         return Version.Parse(version.Split('v')[^1].Split('-')[0]);
     }

--- a/ReHUDVersion.cs
+++ b/ReHUDVersion.cs
@@ -1,4 +1,5 @@
 using Newtonsoft.Json.Linq;
+using ReHUD.Models;
 
 namespace ReHUD;
 

--- a/Services/R3eDataService.cs
+++ b/Services/R3eDataService.cs
@@ -1,0 +1,254 @@
+﻿using ElectronNET.API;
+using ElectronNET.API.Entities;
+using log4net;
+using R3E.Data;
+using ReHUD.Extensions;
+using ReHUD.Interfaces;
+using ReHUD.Models;
+using ReHUD.Utils;
+using System.Reflection;
+
+namespace ReHUD.Services
+{
+    public class R3eDataService : IR3eDataService, IDisposable
+    {
+        public static readonly ILog logger = LogManager.GetLogger(MethodBase.GetCurrentMethod()?.DeclaringType);
+
+        private R3eData data;
+        private R3eExtraData extraData;
+        private FuelData fuelData;
+        private LapPointsData lapPointsData;
+
+        private IRaceRoomObserver raceRoomObserver;
+        private ISharedMemoryService sharedMemoryService;
+
+        private readonly AutoResetEvent resetEvent;
+        private CancellationTokenSource cancellationTokenSource = new();
+
+        private volatile bool _isRunning = false;
+        public bool IsRunning { get => _isRunning; }
+
+        public R3eExtraData Data { get => extraData; }
+        public FuelData FuelData { get => fuelData; }
+        public LapPointsData LapPointsData { get => lapPointsData; }
+
+        private BrowserWindow window;
+        public BrowserWindow HUDWindow { get => window; set => window = value; }
+        private bool? hudShown = false;
+        public bool? HUDShown { get => hudShown; set => hudShown = value; }
+        private string[]? usedKeys;
+        public string[]? UsedKeys { get => usedKeys; set => usedKeys = value; }
+
+        private volatile bool enteredEditMode = false;
+        private volatile bool recordingData = false;
+        private double lastFuel = -1;
+        private volatile int lastLap = -1;
+
+        public R3eDataService(IRaceRoomObserver raceRoomObserver, ISharedMemoryService sharedMemoryService) {
+            this.raceRoomObserver = raceRoomObserver;
+            this.sharedMemoryService = sharedMemoryService;
+
+            extraData = new() {
+                forceUpdateAll = false
+            };
+            fuelData = new();
+            lapPointsData = new();
+
+            resetEvent = new AutoResetEvent(false);
+
+            this.raceRoomObserver.OnProcessStarted += RaceRoomStarted;
+            this.raceRoomObserver.OnProcessStopped += RaceRoomStopped;
+
+            sharedMemoryService.OnDataReady += OnDataReady;
+        }
+
+        public void Load() {
+            fuelData.Load();
+            lapPointsData.Load();
+        }
+
+        public void Save() {
+            fuelData.Save();
+            lapPointsData.Save();
+        }
+
+        public void Dispose() {
+            cancellationTokenSource.Cancel();
+
+            this.raceRoomObserver.OnProcessStarted -= RaceRoomStarted;
+            this.raceRoomObserver.OnProcessStopped -= RaceRoomStopped;
+
+            resetEvent.Dispose();
+        }
+
+        private void RaceRoomStarted() {
+            logger.Info($"RaceRoom started, starting R3eDataService worker");
+
+            cancellationTokenSource.Cancel();
+            cancellationTokenSource.Dispose();
+
+            cancellationTokenSource = new();
+            Task.Run(() => ProcessR3eData(cancellationTokenSource.Token), cancellationTokenSource.Token);
+        }
+
+        private void RaceRoomStopped() {
+            logger.Info($"RaceRoom stopped, stopping R3eDataService worker");
+
+            cancellationTokenSource.Cancel();
+            _isRunning = false;
+        }
+
+        private void OnDataReady(R3eData data) {
+            this.data = data;
+            resetEvent.Set();
+        }
+
+        private async Task ProcessR3eData(CancellationToken cancellationToken) {
+            logger.Info("Starting R3eDataService worker");
+
+            int iter = 0;
+            var userDataClearedForMultiplier = false;
+
+            while (!cancellationToken.IsCancellationRequested) {
+                resetEvent.WaitOne();
+                resetEvent.Reset();
+
+                extraData.timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+                if (data.fuelUseActive != 1 && !userDataClearedForMultiplier) {
+                    userDataClearedForMultiplier = true;
+                    fuelData.Save();
+                    fuelData.Clear();
+                }
+                else if (data.fuelUseActive == 1 && userDataClearedForMultiplier) {
+                    userDataClearedForMultiplier = false;
+                    fuelData.Clear();
+                    fuelData.Load();
+                }
+
+                extraData.rawData = data;
+                extraData.rawData.numCars = Math.Max(data.numCars, data.position); // Bug in shared memory, sometimes numCars is updated in delay, this partially fixes it
+                extraData.rawData.driverData = extraData.rawData.driverData.Take(extraData.rawData.numCars).ToArray();
+                if (data.layoutId != -1 && data.vehicleInfo.modelId != -1 && iter % sharedMemoryService.FrameRate == 0) {
+                    FuelCombination combination = fuelData.GetCombination(data.layoutId, data.vehicleInfo.modelId);
+                    extraData.fuelPerLap = combination.GetAverageFuelUsage();
+                    extraData.fuelLastLap = combination.GetLastLapFuelUsage();
+                    extraData.averageLapTime = combination.GetAverageLapTime();
+                    extraData.bestLapTime = combination.GetBestLapTime();
+                    Tuple<int, double> lapData = Utilities.GetEstimatedLapCount(data, combination);
+                    extraData.estimatedRaceLapCount = lapData.Item1;
+                    extraData.lapsUntilFinish = lapData.Item2;
+                    iter = 0;
+                }
+                iter++;
+
+                lastLap = data.completedLaps;
+
+                Func<Task> saveDataTask = () => {
+                    try {
+                        SaveData(data);
+                    }
+                    catch (Exception e) {
+                        logger.Error("Error saving data", e);
+                    }
+                    return Task.CompletedTask;
+                };
+
+                Func<Task> updateHUDTask = async () => {
+                    if (enteredEditMode) {
+                        extraData.forceUpdateAll = true;
+                        await IpcCommunication.Invoke(window, "r3eData", extraData.Serialize(usedKeys));
+                        extraData.forceUpdateAll = false;
+                        enteredEditMode = false;
+                    }
+                    else {
+                        await IpcCommunication.Invoke(window, "r3eData", extraData.Serialize(usedKeys));
+                    }
+                };
+
+                Func<Task> updateHUDStateTask = async () => {
+                    bool notDriving = data.IsNotDriving();
+                    if (notDriving) {
+                        if (window != null && (hudShown ?? true)) {
+                            Electron.IpcMain.Send(window, "hide");
+                            hudShown = false;
+                        }
+
+                        recordingData = false;
+
+                        if (data.sessionType == -1) {
+                            lastLap = -1;
+                            lastFuel = -1;
+                        }
+                    }
+                    else if (window != null && !(hudShown ?? false)) {
+                        Electron.IpcMain.Send(window, "show");
+                        window.SetAlwaysOnTop(true, OnTopLevel.screenSaver);
+                        hudShown = true;
+                    }
+                };
+
+                await Task.WhenAll(saveDataTask(), updateHUDTask(), updateHUDStateTask());
+            }
+
+            logger.Info("Shared R3eDataService worker thread stopped");
+        }
+
+        private void SaveData(R3eData data) {
+            if (lastLap == -1 || lastLap == data.completedLaps || fuelData == null)
+                return;
+
+            if (!recordingData) {
+                recordingData = true;
+                lastFuel = data.fuelLeft;
+                return;
+            }
+
+            var fuelNow = data.vehicleInfo.engineType == 1 ? data.batterySoC : data.fuelLeft;
+
+            int modelId = data.vehicleInfo.modelId;
+            int layoutId = data.layoutId;
+            FuelCombination combo = fuelData.GetCombination(layoutId, modelId);
+
+            if (data.lapTimePreviousSelf > 0)
+                combo.AddLapTime(data.lapTimePreviousSelf);
+
+            if (data.fuelUseActive >= 1 && lastFuel != -1) {
+                combo.AddFuelUsage(lastFuel - fuelNow, data.lapTimePreviousSelf > 0);
+            }
+
+            if (data.fuelUseActive <= 1)
+                fuelData.Save();
+
+            lastFuel = fuelNow;
+        }
+
+        public void SetEnteredEditMode() {
+            enteredEditMode = true;
+        }
+
+        public void SaveBestLap(int layoutId, int classId, double laptime, double[] points, double pointsPerMeter) {
+            LapPointsCombination combination = lapPointsData.GetCombination(layoutId, classId);
+            combination.Set(laptime, points, pointsPerMeter);
+
+            lapPointsData.Save();
+        }
+        public string LoadBestLap(int layoutId, int classId) {
+            LapPointsCombination? combination = lapPointsData.GetCombination(layoutId, classId, false);
+            if (combination == null)
+                return "{}";
+            return combination.Serialize();
+        }
+
+        public async Task SendEmptyData() {
+            var extraData = new R3eExtraData {
+                forceUpdateAll = true,
+                rawData = new R3eData {
+                    driverData = Array.Empty<DriverData>(),
+                },
+                timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            };
+            logger.Info("Sending empty data for edit mode");
+            await IpcCommunication.Invoke(window, "r3eData", extraData.Serialize(usedKeys));
+        }
+    }
+}

--- a/Services/R3eDataService.cs
+++ b/Services/R3eDataService.cs
@@ -6,13 +6,12 @@ using ReHUD.Extensions;
 using ReHUD.Interfaces;
 using ReHUD.Models;
 using ReHUD.Utils;
-using System.Reflection;
 
 namespace ReHUD.Services
 {
     public class R3eDataService : IR3eDataService, IDisposable
     {
-        public static readonly ILog logger = LogManager.GetLogger(MethodBase.GetCurrentMethod()?.DeclaringType);
+        public static readonly ILog logger = LogManager.GetLogger(typeof(R3eDataService));
 
         private R3eData data;
         private R3eExtraData extraData;
@@ -190,7 +189,7 @@ namespace ReHUD.Services
                 await Task.WhenAll(saveDataTask(), updateHUDTask(), updateHUDStateTask());
             }
 
-            logger.Info("Shared R3eDataService worker thread stopped");
+            logger.Info("R3eDataService worker thread stopped");
         }
 
         private void SaveData(R3eData data) {

--- a/Services/UpdateService.cs
+++ b/Services/UpdateService.cs
@@ -1,0 +1,74 @@
+﻿using ElectronNET.API;
+using ElectronNET.API.Entities;
+using log4net;
+using ReHUD.Interfaces;
+using System.Net.Http.Headers;
+using System.Reflection;
+
+namespace ReHUD.Services
+{
+    public class UpdateService : IUpdateService
+    {
+        private static readonly ILog logger = LogManager.GetLogger(MethodBase.GetCurrentMethod()?.DeclaringType);
+
+        private const string githubUrl = "https://github.com/Yuvix25/ReHUD";
+        private const string githubReleasesUrl = "releases/latest";
+
+        private string? appVersion;
+
+        public string? AppVersion { get => appVersion; }
+
+        public async Task<string> GetAppVersion() => appVersion ??= await Electron.App.GetVersionAsync();
+
+        public async Task CheckForUpdates() {
+            string currentVersion = await GetAppVersion();
+            logger.Info("Checking for updates (current version: v" + currentVersion + ")");
+            string? remoteUrl = await GetRedirectedUrl(githubUrl + "/" + githubReleasesUrl);
+            if (remoteUrl == null) {
+                logger.Error("Could not get remote URL for checking updates");
+                return;
+            }
+
+            string remoteVersionText = remoteUrl.Split('/')[^1];
+
+            Version current = ReHUDVersion.TrimVersion(currentVersion);
+            Version remote = ReHUDVersion.TrimVersion(remoteVersionText);
+
+            if (current.CompareTo(remote) < 0) {
+                logger.Info("Update available: " + remoteVersionText);
+
+                await Startup.ShowMessageBox("A new version is available: " + remoteVersionText, new string[] { "Show me", "Cancel" }, "Update available", MessageBoxType.info).ContinueWith((t) => {
+                    if (t.Result.Response == 0) {
+                        Electron.Shell.OpenExternalAsync(remoteUrl);
+                    }
+                });
+
+                return;
+            }
+            logger.Info("No updates available");
+        }
+
+        private static async Task<string?> GetRedirectedUrl(string url) {
+            //this allows you to set the settings so that we can get the redirect url
+            var handler = new HttpClientHandler() {
+                AllowAutoRedirect = false
+            };
+            string? redirectedUrl = null;
+
+            using (HttpClient client = new(handler))
+            using (HttpResponseMessage response = await client.GetAsync(url))
+            using (HttpContent content = response.Content) {
+                // ... Read the response to see if we have the redirected url
+                if (response.StatusCode == System.Net.HttpStatusCode.Found) {
+                    HttpResponseHeaders headers = response.Headers;
+                    if (headers != null && headers.Location != null) {
+                        redirectedUrl = headers.Location.AbsoluteUri;
+                    }
+                }
+            }
+
+            return redirectedUrl;
+        }
+
+    }
+}

--- a/Services/UpdateService.cs
+++ b/Services/UpdateService.cs
@@ -3,13 +3,12 @@ using ElectronNET.API.Entities;
 using log4net;
 using ReHUD.Interfaces;
 using System.Net.Http.Headers;
-using System.Reflection;
 
 namespace ReHUD.Services
 {
     public class UpdateService : IUpdateService
     {
-        private static readonly ILog logger = LogManager.GetLogger(MethodBase.GetCurrentMethod()?.DeclaringType);
+        private static readonly ILog logger = LogManager.GetLogger(typeof(UpdateService));
 
         private const string githubUrl = "https://github.com/Yuvix25/ReHUD";
         private const string githubReleasesUrl = "releases/latest";

--- a/Settings.cs
+++ b/Settings.cs
@@ -43,7 +43,8 @@ public class SettingsData
         .Add("showDeltaOnInvalidLaps", false)
         .Add("relativeSafeMode", false)
         .Add("check-for-updates", true)
-        .Add("hardwareAcceleration", true);
+        .Add("hardwareAcceleration", true)
+        .Add("enableVRMode", false);
 
     public IEnumerable<KeyValuePair<string, object>> Settings => settings;
 

--- a/SharedMemory.cs
+++ b/SharedMemory.cs
@@ -79,7 +79,6 @@ namespace R3E
         {
             Startup.logger.Info("Starting Shared memory Worker Thread");
 
-            var timeLast = DateTime.UtcNow;
             var found = false;
 
             while (!cancellationToken.IsCancellationRequested)

--- a/SharedMemory.cs
+++ b/SharedMemory.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.IO.MemoryMappedFiles;
 using System.Runtime.InteropServices;
 using R3E.Data;
@@ -5,81 +6,134 @@ using ReHUD;
 
 namespace R3E
 {
-    internal delegate Task SharedMemoryCallback(Shared data);
-
     class SharedMemory : IDisposable
     {
-        private bool found = false;
-        private bool Mapped
-        {
-            get { return _file != null; }
-        }
+        static readonly int SharedSize = Marshal.SizeOf(typeof(Shared));
+        static readonly Type SharedType = typeof(Shared);
+
+        private readonly ProcessObserver raceroomObserver;
+        private TimeSpan timeInterval;
+
+        private CancellationTokenSource cancellationTokenSource = new();
 
         private Shared _data;
-        private MemoryMappedFile? _file;
-        private byte[]? _buffer;
-        private static TimeSpan timeInterval = TimeSpan.FromMilliseconds(16.6); // ~60fps
+        private volatile PeriodicTimer dataTimer;
+        private volatile MemoryMappedFile? _file;
+        private readonly byte[] _buffer;
+        private readonly GCHandle _bufferHandle;
 
-        public static long FrameRate
+        private volatile bool _isRunning = false;
+        public bool IsRunning { get => _isRunning; }
+
+        private bool Mapped
+        {
+            get => _file != null;
+        }
+
+        public event Action<Shared> OnDataReady;
+
+        public long FrameRate
         {
             get { return (long)(1000.0 / timeInterval.TotalMilliseconds); }
-            set {
+            set
+            {
                 timeInterval = TimeSpan.FromMilliseconds(1000.0 / value);
+                dataTimer.Dispose();
+                dataTimer = new(timeInterval);
             }
+        }
+
+        public SharedMemory(ProcessObserver raceroomObserver, TimeSpan? refreshRate)
+        {
+            this.raceroomObserver = raceroomObserver;
+            this.raceroomObserver.OnProcessStarted += RaceRoomStarted;
+            this.raceroomObserver.OnProcessStopped += RaceRoomStopped;
+
+            _buffer = new byte[SharedSize];
+            _bufferHandle = GCHandle.Alloc(_buffer, GCHandleType.Pinned);
+
+            timeInterval = refreshRate ?? TimeSpan.FromMilliseconds(16.6); // ~60fps
+            dataTimer = new(timeInterval);
+        }
+
+        private void RaceRoomStarted()
+        {
+            Startup.logger.Info($"RaceRoom started, starting shared memory worker");
+
+            cancellationTokenSource.Cancel();
+            cancellationTokenSource.Dispose();
+
+            cancellationTokenSource = new();
+            Task.Run(() => ProcessSharedMemory(cancellationTokenSource.Token), cancellationTokenSource.Token);
+        }
+
+        private void RaceRoomStopped()
+        {
+            Startup.logger.Info($"RaceRoom stopped, stopping shared memory worker");
+
+            cancellationTokenSource.Cancel();
+            _isRunning = false;
+        }
+
+        private async Task ProcessSharedMemory(CancellationToken cancellationToken)
+        {
+            Startup.logger.Info("Starting Shared memory Worker Thread");
+
+            var timeLast = DateTime.UtcNow;
+            var found = false;
+
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                if (await dataTimer.WaitForNextTickAsync(cancellationToken))
+                {
+                    if (!Mapped)
+                    {
+                        if (!found)
+                            Startup.logger.Info("Found RRRE.exe, mapping shared memory...");
+
+                        found = true;
+
+                        if (Map())
+                        {
+                            Startup.logger.Info("Memory mapped successfully");
+                        }
+                        else
+                        {
+                            Startup.logger.Warn("Failed to map memory");
+                            Thread.Sleep(1000);
+                        }
+                    }
+
+                    if (Mapped && await Read())
+                    {
+                        _isRunning = true;
+                        OnDataReady?.Invoke(_data);
+                    }
+                    else
+                    {
+                        _isRunning = false;
+                    }
+                }
+            }
+
+            Startup.logger.Info("Shared memory worker thread stopped");
+
+            _file = null;
         }
 
         public void Dispose()
         {
+            cancellationTokenSource.Cancel();
+
+            raceroomObserver.OnProcessStarted -= RaceRoomStarted;
+            raceroomObserver.OnProcessStopped -= RaceRoomStopped;
+
             if (_file != null)
                 _file.Dispose();
-        }
 
-        public static bool IsRunning { get; private set; } = false;
+            dataTimer.Dispose();
 
-        public async Task Run(SharedMemoryCallback callback)
-        {
-            var timeLast = DateTime.UtcNow;
-
-            Startup.logger.Info("Looking for RRRE.exe...");
-
-            while (true)
-            {
-                var timeNow = DateTime.UtcNow;
-
-                var timeDiff = timeNow.Subtract(timeLast);
-                if (timeDiff < timeInterval)
-                {
-                    await Task.Delay(timeInterval - timeDiff);
-                    continue;
-                }
-
-                timeLast = timeNow;
-
-                if (Utilities.IsRaceRoomRunning() && !Mapped)
-                {
-                    if (!found)
-                        Startup.logger.Info("Found RRRE.exe, mapping shared memory...");
-
-                    found = true;
-
-                    if (Map())
-                    {
-                        Startup.logger.Info("Memory mapped successfully");
-
-                        _buffer = new byte[Marshal.SizeOf(typeof(Shared))];
-                    }
-                }
-
-                if (Mapped && Read())
-                {
-                    IsRunning = true;
-                    await callback(_data);
-                }
-                else
-                {
-                    IsRunning = false;
-                }
-            }
+            _bufferHandle.Free();
         }
 
         private bool Map()
@@ -95,25 +149,21 @@ namespace R3E
             }
         }
 
-        private bool Read()
+        private async Task<bool> Read()
         {
             if (_file == null)
                 return false;
 
             try
             {
-                var _view = _file.CreateViewStream();
-                BinaryReader _stream = new(_view);
-                _buffer = _stream.ReadBytes(Marshal.SizeOf(typeof(Shared)));
-                GCHandle _handle = GCHandle.Alloc(_buffer, GCHandleType.Pinned);
+                using var _view = _file.CreateViewStream();
+                await _view.ReadAsync(_buffer, 0, SharedSize);
 
-                var res = Marshal.PtrToStructure(_handle.AddrOfPinnedObject(), typeof(Shared));
+                var res = Marshal.PtrToStructure(_bufferHandle.AddrOfPinnedObject(), SharedType);
                 if (res == null)
                     return false;
 
                 _data = (Shared)res;
-                _handle.Free();
-
                 return true;
             }
             catch (Exception e)

--- a/Startup.cs
+++ b/Startup.cs
@@ -8,7 +8,6 @@ using System.Net.Http.Headers;
 using R3E;
 using SignalRChat.Hubs;
 using Newtonsoft.Json.Linq;
-using System.Diagnostics;
 
 namespace ReHUD;
 

--- a/Startup.cs
+++ b/Startup.cs
@@ -1,13 +1,13 @@
 using ElectronNET.API;
 using ElectronNET.API.Entities;
-using Newtonsoft.Json;
 using log4net;
 using log4net.Config;
-using System.Reflection;
-using System.Net.Http.Headers;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using R3E;
 using SignalRChat.Hubs;
-using Newtonsoft.Json.Linq;
+using System.Net.Http.Headers;
+using System.Reflection;
 
 namespace ReHUD;
 
@@ -21,23 +21,20 @@ public class Startup
     private ProcessObserver raceroomObserver;
     private SharedMemory sharedMemory;
 
-    public Startup(IConfiguration configuration)
-    {
+    public Startup(IConfiguration configuration) {
         Configuration = configuration;
     }
 
     public IConfiguration Configuration { get; }
 
     // This method gets called by the runtime. Use this method to add services to the container.
-    public void ConfigureServices(IServiceCollection services)
-    {
+    public void ConfigureServices(IServiceCollection services) {
         services.AddSignalR();
         services.AddRazorPages();
     }
 
     // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-    public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
-    {
+    public void Configure(IApplicationBuilder app, IWebHostEnvironment env) {
         logFilePath = Path.Combine(JsonUserData.dataPath, "ReHUD.log");
         GlobalContext.Properties["LogFilePath"] = logFilePath;
 
@@ -50,8 +47,7 @@ public class Startup
         raceroomObserver.Start();
 
         version.Load();
-        _ = AppVersion().ContinueWith(async (t) =>
-        {
+        _ = AppVersion().ContinueWith(async (t) => {
             await version.Update(t.Result);
             lapPointsData.Load();
             settings.Load();
@@ -59,34 +55,27 @@ public class Startup
 
             HudLayout.LoadHudLayouts();
 
-            try
-            {
+            try {
                 string preset = await Electron.App.CommandLine.GetSwitchValueAsync("preset");
-                if (preset != null && preset.Length > 0)
-                {
+                if (preset != null && preset.Length > 0) {
                     HudLayout? layout = HudLayout.GetHudLayout(preset);
-                    if (layout != null)
-                    {
+                    if (layout != null) {
                         HudLayout.SetActiveLayout(layout);
                     }
-                    else
-                    {
+                    else {
                         logger.Warn("Could not find preset: " + preset);
                     }
                 }
             }
-            catch (Exception e)
-            {
+            catch (Exception e) {
                 logger.Error("Error loading preset", e);
             }
         });
 
-        if (env.IsDevelopment())
-        {
+        if (env.IsDevelopment()) {
             app.UseDeveloperExceptionPage();
         }
-        else
-        {
+        else {
             app.UseExceptionHandler("/Error");
             app.UseHsts();
         }
@@ -98,26 +87,20 @@ public class Startup
 
         app.UseAuthorization();
 
-        app.UseEndpoints(endpoints =>
-        {
+        app.UseEndpoints(endpoints => {
             endpoints.MapHub<ReHUDHub>("/ReHUDHub");
             endpoints.MapRazorPages();
         });
 
         Electron.App.CommandLine.AppendSwitch("enable-transparent-visuals");
 
-        if (HybridSupport.IsElectronActive)
-        {
-            Electron.App.Ready += async () =>
-            {
-                try
-                {
-                    await Electron.IpcMain.On("get-port", (args) =>
-                    {
+        if (HybridSupport.IsElectronActive) {
+            Electron.App.Ready += async () => {
+                try {
+                    await Electron.IpcMain.On("get-port", (args) => {
                         var windows = new[] { MainWindow, SettingsWindow }.Where(x => x != null);
 
-                        foreach (var window in windows)
-                        {
+                        foreach (var window in windows) {
                             Electron.IpcMain.Send(window, "port", BridgeSettings.WebPort);
                         }
                     });
@@ -125,13 +108,11 @@ public class Startup
                     await CreateSettingsWindow(env);
 
                     await Task.Delay(1000); // TODO
-                    if (settings.DidLoad)
-                    {
+                    if (settings.DidLoad) {
                         await LoadSettings();
                     }
                 }
-                catch (Exception e)
-                {
+                catch (Exception e) {
                     logger.Error("Error creating windows", e);
                 }
             };
@@ -157,24 +138,20 @@ public class Startup
 
     private string[]? usedKeys = null;
 
-    private static async Task<BrowserWindow> CreateWindowAsync(BrowserWindowOptions options, string loadUrl = "/")
-    {
+    private static async Task<BrowserWindow> CreateWindowAsync(BrowserWindowOptions options, string loadUrl = "/") {
         loadUrl = "http://localhost:" + BridgeSettings.WebPort + loadUrl;
         return await Electron.WindowManager.CreateWindowAsync(options, loadUrl);
     }
 
-    private async Task CreateMainWindow()
-    {
-        await Electron.IpcMain.On("used-keys", (args) =>
-        {
+    private async Task CreateMainWindow() {
+        await Electron.IpcMain.On("used-keys", (args) => {
             if (args == null)
                 return;
 
             usedKeys = ((JArray)args).Select(x => (string?)x).Where(x => x != null).ToArray()!;
         });
 
-        MainWindow = await CreateWindowAsync(new BrowserWindowOptions()
-        {
+        MainWindow = await CreateWindowAsync(new BrowserWindowOptions() {
             Resizable = false,
             Fullscreen = true,
             Minimizable = false,
@@ -183,16 +160,14 @@ public class Startup
             Transparent = true,
             BackgroundColor = BLACK_TRANSPARENT,
             Icon = Path.Combine(Directory.GetCurrentDirectory(), "wwwroot", "ReHUD.png"),
-            WebPreferences = new WebPreferences()
-            {
+            WebPreferences = new WebPreferences() {
                 EnableRemoteModule = true,
                 NodeIntegration = true,
             },
         }, loadUrl: "/Index");
 
         bool gotLock = await Electron.App.RequestSingleInstanceLockAsync((args, arg) => { });
-        if (!gotLock)
-        {
+        if (!gotLock) {
             await ShowMessageBox(MainWindow, anotherInstanceMessage, "Error", MessageBoxType.error);
             Electron.App.Quit();
             return;
@@ -201,75 +176,61 @@ public class Startup
         MainWindow.SetAlwaysOnTop(true, OnTopLevel.screenSaver);
         MainWindow.SetIgnoreMouseEvents(true);
 
-        await Electron.IpcMain.On("get-hud-layout", (args) =>
-        {
+        await Electron.IpcMain.On("get-hud-layout", (args) => {
             SendHudLayout();
         });
 
-        await Electron.IpcMain.On("set-hud-layout", (args) =>
-        {
+        await Electron.IpcMain.On("set-hud-layout", (args) => {
             if (args == null || args.ToString() == null)
                 return;
 
             string argsString = args.ToString()!;
 
             HudLayout? layout;
-            if (argsString.Length > 0 && argsString[0] == '{')
-            {
-                try
-                {
+            if (argsString.Length > 0 && argsString[0] == '{') {
+                try {
                     Dictionary<string, HudElement>? layoutElements = JsonConvert.DeserializeObject<Dictionary<string, HudElement>>(argsString);
-                    if (layoutElements == null)
-                    {
+                    if (layoutElements == null) {
                         logger.Error("Invalid HUD layout: " + args);
                         return;
                     }
                     layout = HudLayout.ActiveHudLayout;
-                    if (layout == null)
-                    {
+                    if (layout == null) {
                         logger.Warn("No active HUD layout, creating a new one");
                         layout = HudLayout.AddHudLayout(new HudLayout(true));
                     }
                     layout.UpdateElements(layoutElements);
                 }
-                catch (Exception e)
-                {
+                catch (Exception e) {
                     logger.Error("Error deserializing HUD layout", e);
                     return;
                 }
             }
-            else
-            {
+            else {
                 layout = HudLayout.GetHudLayout(argsString);
                 if (layout != null) HudLayout.SetActiveLayout(layout);
             }
-            if (layout == null)
-            {
+            if (layout == null) {
                 logger.Error("Invalid HUD layout: " + args);
                 return;
             }
             SetHudLayout(layout);
         });
 
-        await Electron.IpcMain.On("load-replay-preset", (args) =>
-        {
+        await Electron.IpcMain.On("load-replay-preset", (args) => {
             var layout = HudLayout.LoadReplayLayout();
-            if (layout != null)
-            {
+            if (layout != null) {
                 SetHudLayout(layout, true, false);
             }
         });
-        await Electron.IpcMain.On("unload-replay-preset", (args) =>
-        {
+        await Electron.IpcMain.On("unload-replay-preset", (args) => {
             var layout = HudLayout.UnloadReplayLayout();
-            if (layout != null)
-            {
+            if (layout != null) {
                 SetHudLayout(layout, true);
             }
         });
 
-        await Electron.IpcMain.On("update-preset-name", async (args) =>
-        {
+        await Electron.IpcMain.On("update-preset-name", async (args) => {
             JArray array = (JArray)args;
             string? oldName = (string?)array[0];
             string? newName = (string?)array[1];
@@ -278,14 +239,12 @@ public class Startup
                 return;
 
             var layout = HudLayout.GetHudLayout(oldName);
-            if (layout != null)
-            {
+            if (layout != null) {
                 await RenameLayout(layout, newName);
             }
         });
 
-        await Electron.IpcMain.On("update-preset-is-replay", (args) =>
-        {
+        await Electron.IpcMain.On("update-preset-is-replay", (args) => {
             JArray array = (JArray)args;
             string? name = (string?)array[0];
             bool isReplay = (bool)array[1];
@@ -294,8 +253,7 @@ public class Startup
                 return;
 
             var layout = HudLayout.GetHudLayout(name);
-            if (layout != null)
-            {
+            if (layout != null) {
                 layout.IsReplayLayout = isReplay;
                 layout.Save();
 
@@ -303,8 +261,7 @@ public class Startup
             }
         });
 
-        await Electron.IpcMain.On("toggle-element", (args) =>
-        {
+        await Electron.IpcMain.On("toggle-element", (args) => {
             JArray array = (JArray)args;
             string? elementId = (string?)array[0];
             bool shown = (bool)array[1];
@@ -315,32 +272,26 @@ public class Startup
             Electron.IpcMain.Send(MainWindow, "toggle-element", elementId, shown);
         });
 
-        await Electron.IpcMain.On("reset-active-layout", (args) =>
-        {
-            try
-            {
+        await Electron.IpcMain.On("reset-active-layout", (args) => {
+            try {
                 var layout = HudLayout.ActiveHudLayout;
-                if (layout != null)
-                {
+                if (layout != null) {
                     layout.Reset();
                     SendHudLayout();
                 }
             }
-            catch (Exception e)
-            {
+            catch (Exception e) {
                 logger.Error("Error resetting HUD layout", e);
             }
         });
 
-        await Electron.IpcMain.On("request-layout-visibility", (args) =>
-        {
+        await Electron.IpcMain.On("request-layout-visibility", (args) => {
             isShown = null;
         });
 
         RunLoop(MainWindow);
 
-        Electron.App.BeforeQuit += async (QuitEventArgs args) =>
-        {
+        Electron.App.BeforeQuit += async (QuitEventArgs args) => {
             args.PreventDefault();
             Electron.IpcMain.Send(MainWindow, "quit");
             Electron.IpcMain.Send(SettingsWindow, "quit");
@@ -351,15 +302,13 @@ public class Startup
         MainWindow.OnClosed += () => Electron.App.Quit();
     }
 
-    public static void SaveBestLap(int layoutId, int classId, double laptime, double[] points, double pointsPerMeter)
-    {
+    public static void SaveBestLap(int layoutId, int classId, double laptime, double[] points, double pointsPerMeter) {
         LapPointsCombination combination = lapPointsData.GetCombination(layoutId, classId);
         combination.Set(laptime, points, pointsPerMeter);
 
         lapPointsData.Save();
     }
-    public static string LoadBestLap(int layoutId, int classId)
-    {
+    public static string LoadBestLap(int layoutId, int classId) {
         LapPointsCombination? combination = lapPointsData.GetCombination(layoutId, classId, false);
         if (combination == null)
             return "{}";
@@ -367,26 +316,22 @@ public class Startup
     }
 
 
-    private static void SendHudLayout()
-    {
+    private static void SendHudLayout() {
         var layout = GetHudLayout();
         if (layout == null)
             return;
         SendHudLayout(layout);
     }
 
-    private static void SendHudLayout(HudLayout layout, bool sendToSettings = true)
-    {
+    private static void SendHudLayout(HudLayout layout, bool sendToSettings = true) {
         Electron.IpcMain.Send(MainWindow, "hud-layout", layout.SerializeElements());
-        if (SettingsWindow != null && sendToSettings)
-        {
+        if (SettingsWindow != null && sendToSettings) {
             Electron.IpcMain.Send(SettingsWindow, "hud-layouts", HudLayout.SerializeLayouts(true));
         }
     }
 
 
-    private async Task InitSettingsWindow()
-    {
+    private async Task InitSettingsWindow() {
         Electron.IpcMain.Send(MainWindow, "settings", settings.Serialize());
         Electron.IpcMain.Send(SettingsWindow, "settings", settings.Serialize());
         Electron.IpcMain.Send(SettingsWindow, "version", await AppVersion());
@@ -396,15 +341,12 @@ public class Startup
     private bool enteredEditMode = false;
     public static bool IsInEditMode { get; private set; }
 
-    private async Task CreateSettingsWindow(IWebHostEnvironment env)
-    {
-        SettingsWindow = await CreateWindowAsync(new BrowserWindowOptions()
-        {
+    private async Task CreateSettingsWindow(IWebHostEnvironment env) {
+        SettingsWindow = await CreateWindowAsync(new BrowserWindowOptions() {
             Width = 800,
             Height = 600,
             Icon = Path.Combine(Directory.GetCurrentDirectory(), "wwwroot", "ReHUD.png"),
-            WebPreferences = new WebPreferences()
-            {
+            WebPreferences = new WebPreferences() {
                 EnableRemoteModule = true,
                 NodeIntegration = true,
             },
@@ -415,32 +357,27 @@ public class Startup
         if (!env.IsDevelopment())
             SettingsWindow.RemoveMenu();
 
-        await Electron.IpcMain.On("restart-app", (args) =>
-        {
+        await Electron.IpcMain.On("restart-app", (args) => {
             Electron.App.Relaunch();
             Electron.App.Exit(0);
         });
 
-        await Electron.IpcMain.On("load-settings", async (data) =>
-        {
+        await Electron.IpcMain.On("load-settings", async (data) => {
             await InitSettingsWindow();
         });
 
-        await Electron.IpcMain.On("check-for-updates", async (data) =>
-        {
+        await Electron.IpcMain.On("check-for-updates", async (data) => {
             await CheckForUpdates();
         });
 
-        await Electron.IpcMain.On("lock-overlay", async (data) =>
-        {
+        await Electron.IpcMain.On("lock-overlay", async (data) => {
             JArray array = (JArray)data;
             bool locked = (bool)array[0];
             bool save = (bool)array[1];
 
             if (!locked) // enter edit mode
             {
-                if (MainWindow != null)
-                {
+                if (MainWindow != null) {
                     await IpcCommunication.Invoke(MainWindow, "edit-mode");
 
                     logger.Info("Entering edit mode");
@@ -448,13 +385,10 @@ public class Startup
                     enteredEditMode = true;
                     IsInEditMode = true;
 
-                    if (!sharedMemory.IsRunning)
-                    {
-                        var extraData = new ExtraData
-                        {
+                    if (!sharedMemory.IsRunning) {
+                        var extraData = new ExtraData {
                             forceUpdateAll = true,
-                            rawData = new R3E.Data.Shared
-                            {
+                            rawData = new R3E.Data.Shared {
                                 driverData = Array.Empty<R3E.Data.DriverData>(),
                             },
                             timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
@@ -464,19 +398,16 @@ public class Startup
                     }
                 }
             }
-            else
-            {
+            else {
                 isShown = null;
                 IsInEditMode = false;
 
-                if (!sharedMemory.IsRunning)
-                {
+                if (!sharedMemory.IsRunning) {
                     Electron.IpcMain.Send(MainWindow, "hide");
                 }
             }
 
-            if (MainWindow != null)
-            {
+            if (MainWindow != null) {
                 MainWindow.SetIgnoreMouseEvents(locked);
                 MainWindow.SetAlwaysOnTop(locked, OnTopLevel.screenSaver);
             }
@@ -485,8 +416,7 @@ public class Startup
             if (locked && save) // save
             {
                 string? newName = array.Count > 2 ? (string?)array[2] : null;
-                if (newName != null && HudLayout.ActiveHudLayout != null && HudLayout.ActiveHudLayout.Name != newName)
-                {
+                if (newName != null && HudLayout.ActiveHudLayout != null && HudLayout.ActiveHudLayout.Name != newName) {
                     await RenameActiveLayout(newName);
                 }
                 Electron.IpcMain.Send(MainWindow, "save-hud-layout");
@@ -499,8 +429,7 @@ public class Startup
             }
         });
 
-        await Electron.IpcMain.On("set-setting", (arg) =>
-        {
+        await Electron.IpcMain.On("set-setting", (arg) => {
             Electron.IpcMain.Send(MainWindow, "set-setting", arg.ToString());
             JArray array = (JArray)arg;
             if (array.Count == 2 && array[0] != null && array[0].Type == JTokenType.String)
@@ -510,32 +439,26 @@ public class Startup
         });
 
 
-        await Electron.IpcMain.On("show-log-file", async (arg) =>
-        {
-            if (logFilePath == null)
-            {
+        await Electron.IpcMain.On("show-log-file", async (arg) => {
+            if (logFilePath == null) {
                 await ShowMessageBox(SettingsWindow, logFilePathWarning, "Warning", MessageBoxType.warning);
             }
-            else
-            {
+            else {
                 await Electron.Shell.ShowItemInFolderAsync(Path.Combine(logFilePath));
             }
         });
 
-        await Electron.IpcMain.On("new-hud-layout", (arg) =>
-        {
+        await Electron.IpcMain.On("new-hud-layout", (arg) => {
             var layout = HudLayout.AddHudLayout(new HudLayout(true));
             SendHudLayout(layout);
         });
 
-        await Electron.IpcMain.On("delete-hud-layout", async (arg) =>
-        {
+        await Electron.IpcMain.On("delete-hud-layout", async (arg) => {
             string? name = arg?.ToString();
             if (name == null)
                 return;
             var layout = HudLayout.GetHudLayout(name);
-            if (layout != null)
-            {
+            if (layout != null) {
                 await layout.DeleteLayout();
                 SendHudLayout();
             }
@@ -545,12 +468,10 @@ public class Startup
     }
 
 
-    private static object? ConvertJToken(JToken token)
-    {
+    private static object? ConvertJToken(JToken token) {
         if (token == null)
             return null;
-        switch (token.Type)
-        {
+        switch (token.Type) {
             case JTokenType.Object:
                 return token.Children<JProperty>().ToDictionary(prop => prop.Name, prop => ConvertJToken(prop.Value));
             case JTokenType.Array:
@@ -561,20 +482,17 @@ public class Startup
     }
 
     private string? appVersion;
-    private async Task<string> AppVersion()
-    {
+    private async Task<string> AppVersion() {
         return appVersion ??= await Electron.App.GetVersionAsync();
     }
 
 
 
-    private async Task CheckForUpdates()
-    {
+    private async Task CheckForUpdates() {
         string currentVersion = await AppVersion();
         logger.Info("Checking for updates (current version: v" + currentVersion + ")");
         string? remoteUrl = await GetRedirectedUrl(githubUrl + "/" + githubReleasesUrl);
-        if (remoteUrl == null)
-        {
+        if (remoteUrl == null) {
             logger.Error("Could not get remote URL for checking updates");
             return;
         }
@@ -584,14 +502,11 @@ public class Startup
         Version current = ReHUDVersion.TrimVersion(currentVersion);
         Version remote = ReHUDVersion.TrimVersion(remoteVersionText);
 
-        if (current.CompareTo(remote) < 0)
-        {
+        if (current.CompareTo(remote) < 0) {
             logger.Info("Update available: " + remoteVersionText);
 
-            await ShowMessageBox("A new version is available: " + remoteVersionText, new string[] { "Show me", "Cancel" }, "Update available", MessageBoxType.info).ContinueWith((t) =>
-            {
-                if (t.Result.Response == 0)
-                {
+            await ShowMessageBox("A new version is available: " + remoteVersionText, new string[] { "Show me", "Cancel" }, "Update available", MessageBoxType.info).ContinueWith((t) => {
+                if (t.Result.Response == 0) {
                     Electron.Shell.OpenExternalAsync(remoteUrl);
                 }
             });
@@ -601,25 +516,20 @@ public class Startup
         logger.Info("No updates available");
     }
 
-    public static async Task<string?> GetRedirectedUrl(string url)
-    {
+    public static async Task<string?> GetRedirectedUrl(string url) {
         //this allows you to set the settings so that we can get the redirect url
-        var handler = new HttpClientHandler()
-        {
+        var handler = new HttpClientHandler() {
             AllowAutoRedirect = false
         };
         string? redirectedUrl = null;
 
         using (HttpClient client = new(handler))
         using (HttpResponseMessage response = await client.GetAsync(url))
-        using (HttpContent content = response.Content)
-        {
+        using (HttpContent content = response.Content) {
             // ... Read the response to see if we have the redirected url
-            if (response.StatusCode == System.Net.HttpStatusCode.Found)
-            {
+            if (response.StatusCode == System.Net.HttpStatusCode.Found) {
                 HttpResponseHeaders headers = response.Headers;
-                if (headers != null && headers.Location != null)
-                {
+                if (headers != null && headers.Location != null) {
                     redirectedUrl = headers.Location.AbsoluteUri;
                 }
             }
@@ -629,42 +539,35 @@ public class Startup
     }
 
 
-    public static async Task<MessageBoxResult> ShowMessageBox(BrowserWindow? window, string message, string title = "Error", MessageBoxType type = MessageBoxType.error)
-    {
+    public static async Task<MessageBoxResult> ShowMessageBox(BrowserWindow? window, string message, string title = "Error", MessageBoxType type = MessageBoxType.error) {
         MessageBoxOptions options = PrepareMessageBox(message, title, type);
         if (window == null)
             return await Electron.Dialog.ShowMessageBoxAsync(options);
         return await Electron.Dialog.ShowMessageBoxAsync(window, options);
     }
 
-    public static async Task<MessageBoxResult> ShowMessageBox(string message, string title = "Error", MessageBoxType type = MessageBoxType.error)
-    {
+    public static async Task<MessageBoxResult> ShowMessageBox(string message, string title = "Error", MessageBoxType type = MessageBoxType.error) {
         MessageBoxOptions options = PrepareMessageBox(message, title, type);
         return await Electron.Dialog.ShowMessageBoxAsync(options);
     }
 
-    public static async Task<MessageBoxResult> ShowMessageBox(string message, string[] buttons, string title = "Error", MessageBoxType type = MessageBoxType.error)
-    {
+    public static async Task<MessageBoxResult> ShowMessageBox(string message, string[] buttons, string title = "Error", MessageBoxType type = MessageBoxType.error) {
         MessageBoxOptions options = PrepareMessageBox(message, title, type);
         options.Buttons = buttons;
         return await Electron.Dialog.ShowMessageBoxAsync(options);
     }
 
-    public static void QuitApp()
-    {
+    public static void QuitApp() {
         Electron.App.Quit();
     }
 
-    private static MessageBoxOptions PrepareMessageBox(string message, string title = "Error", MessageBoxType type = MessageBoxType.error)
-    {
-        MessageBoxOptions options = new(message)
-        {
+    private static MessageBoxOptions PrepareMessageBox(string message, string title = "Error", MessageBoxType type = MessageBoxType.error) {
+        MessageBoxOptions options = new(message) {
             Type = type,
             Title = title,
         };
 
-        switch (type)
-        {
+        switch (type) {
             case MessageBoxType.error:
                 logger.Error(message);
                 break;
@@ -679,8 +582,7 @@ public class Startup
         return options;
     }
 
-    private async Task SaveSetting(string key, object value, bool sendToWindow = true)
-    {
+    private async Task SaveSetting(string key, object value, bool sendToWindow = true) {
         settings.Data.Set(key, value);
         settings.Save();
 
@@ -690,21 +592,16 @@ public class Startup
             Electron.IpcMain.Send(SettingsWindow, "settings", settings.Serialize());
     }
 
-    public async Task LoadSettings(string? key = null, object? value = null)
-    {
-        if (key == null)
-        {
-            foreach (var setting in settings.Data.Settings)
-            {
+    public async Task LoadSettings(string? key = null, object? value = null) {
+        if (key == null) {
+            foreach (var setting in settings.Data.Settings) {
                 await LoadSettings(setting.Key, setting.Value);
             }
         }
-        else
-        {
+        else {
             if (value == null)
                 return;
-            switch (key)
-            {
+            switch (key) {
                 case "screenToUse":
                     await LoadMonitor(value.ToString());
                     break;
@@ -725,20 +622,15 @@ public class Startup
     }
 
     private static readonly string[] hardwareAccelerationSettings = new string[] { "disable-gpu-compositing", "disable-gpu", "disable-software-rasterizer" };
-    private static void SetHardwareAccelerationEnabled(bool enabled)
-    {
+    private static void SetHardwareAccelerationEnabled(bool enabled) {
         logger.Info("Setting hardware acceleration: " + enabled);
-        if (enabled)
-        {
-            foreach (var setting in hardwareAccelerationSettings)
-            {
+        if (enabled) {
+            foreach (var setting in hardwareAccelerationSettings) {
                 Electron.App.CommandLine.RemoveSwitch(setting);
             }
         }
-        else
-        {
-            foreach (var setting in hardwareAccelerationSettings)
-            {
+        else {
+            foreach (var setting in hardwareAccelerationSettings) {
                 Electron.App.CommandLine.AppendSwitch(setting);
             }
         }
@@ -759,8 +651,7 @@ public class Startup
             || value is ushort;
     }
 
-    private static async Task LoadMonitor(string? value = null)
-    {
+    private static async Task LoadMonitor(string? value = null) {
         if (MainWindow == null)
             return;
         var monitorId = value ?? await GetMainWindowDisplay();
@@ -773,25 +664,20 @@ public class Startup
         MainWindow.SetBounds(monitor.WorkArea);
     }
 
-    private static HudLayout? GetHudLayout()
-    {
-        try
-        {
+    private static HudLayout? GetHudLayout() {
+        try {
             var layout = HudLayout.ActiveHudLayout;
             layout ??= HudLayout.AddHudLayout(new HudLayout(true));
             return layout;
         }
-        catch (Exception e)
-        {
+        catch (Exception e) {
             logger.Error("Error getting HUD layout", e);
             return null;
         }
     }
 
-    private static void SetHudLayout(HudLayout layout, bool sendToSettings = false, bool removeBefore = true)
-    {
-        if (IsInEditMode)
-        {
+    private static void SetHudLayout(HudLayout layout, bool sendToSettings = false, bool removeBefore = true) {
+        if (IsInEditMode) {
             logger.Info("Cannot set HUD layout while in edit mode");
             return;
         }
@@ -800,32 +686,26 @@ public class Startup
         SendHudLayout(layout, sendToSettings);
     }
 
-    private static async Task<bool> RenameActiveLayout(string newName)
-    {
-        if (HudLayout.ActiveHudLayout == null)
-        {
+    private static async Task<bool> RenameActiveLayout(string newName) {
+        if (HudLayout.ActiveHudLayout == null) {
             logger.Error("No active HUD layout");
             return false;
         }
         return await RenameLayout(HudLayout.ActiveHudLayout, newName);
     }
 
-    private static async Task<bool> RenameLayout(HudLayout layout, string newName)
-    {
+    private static async Task<bool> RenameLayout(HudLayout layout, string newName) {
         bool res = await layout.Rename(newName);
-        if (res)
-        {
+        if (res) {
             layout.Save();
         }
-        else
-        {
+        else {
             DiscardNameChange();
         }
         return res;
     }
 
-    private static void DiscardNameChange()
-    {
+    private static void DiscardNameChange() {
         HudLayout layout = HudLayout.ActiveHudLayout ?? throw new InvalidOperationException("No active HUD layout");
         Electron.IpcMain.Send(SettingsWindow, "discard-name-change", layout.Name);
     }
@@ -834,29 +714,24 @@ public class Startup
 
     bool? isShown = null;
 
-    private void RunLoop(BrowserWindow window)
-    {
+    private void RunLoop(BrowserWindow window) {
         fuelData.Load();
 
         Thread.Sleep(1000);
 
         int iter = 0;
-        ExtraData extraData = new()
-        {
+        ExtraData extraData = new() {
             forceUpdateAll = false,
         };
 
-        sharedMemory.OnDataReady += async (data) =>
-        {
+        sharedMemory.OnDataReady += async (data) => {
             extraData.timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
-            if (data.fuelUseActive != 1 && !userDataClearedForMultiplier)
-            {
+            if (data.fuelUseActive != 1 && !userDataClearedForMultiplier) {
                 userDataClearedForMultiplier = true;
                 fuelData.Save();
                 fuelData.Clear();
             }
-            else if (data.fuelUseActive == 1 && userDataClearedForMultiplier)
-            {
+            else if (data.fuelUseActive == 1 && userDataClearedForMultiplier) {
                 userDataClearedForMultiplier = false;
                 fuelData.Clear();
                 fuelData.Load();
@@ -865,8 +740,7 @@ public class Startup
             extraData.rawData = data;
             extraData.rawData.numCars = Math.Max(data.numCars, data.position); // Bug in shared memory, sometimes numCars is updated in delay, this partially fixes it
             extraData.rawData.driverData = extraData.rawData.driverData.Take(extraData.rawData.numCars).ToArray();
-            if (data.layoutId != -1 && data.vehicleInfo.modelId != -1 && iter % sharedMemory.FrameRate == 0)
-            {
+            if (data.layoutId != -1 && data.vehicleInfo.modelId != -1 && iter % sharedMemory.FrameRate == 0) {
                 FuelCombination combination = fuelData.GetCombination(data.layoutId, data.vehicleInfo.modelId);
                 extraData.fuelPerLap = combination.GetAverageFuelUsage();
                 extraData.fuelLastLap = combination.GetLastLapFuelUsage();
@@ -879,47 +753,39 @@ public class Startup
             }
             iter++;
 
-            try
-            {
+            try {
                 SaveData(data);
             }
-            catch (Exception e)
-            {
+            catch (Exception e) {
                 logger.Error("Error saving data", e);
             }
 
             lastLap = data.completedLaps;
             bool notDriving = data.gameInMenus == 1 || (data.gamePaused == 1 && data.gameInReplay == 0) || data.sessionType == -1;
-            if (enteredEditMode)
-            {
+            if (enteredEditMode) {
                 extraData.forceUpdateAll = true;
                 await IpcCommunication.Invoke(window, "r3eData", extraData.Serialize(usedKeys));
                 extraData.forceUpdateAll = false;
                 enteredEditMode = false;
             }
-            else
-            {
+            else {
                 await IpcCommunication.Invoke(window, "r3eData", extraData.Serialize(usedKeys));
             }
 
-            if (notDriving)
-            {
-                if (window != null && (isShown ?? true))
-                {
+            if (notDriving) {
+                if (window != null && (isShown ?? true)) {
                     Electron.IpcMain.Send(window, "hide");
                     isShown = false;
                 }
 
                 recordingData = false;
 
-                if (data.sessionType == -1)
-                {
+                if (data.sessionType == -1) {
                     lastLap = -1;
                     lastFuel = -1;
                 }
             }
-            else if (window != null && !(isShown ?? false))
-            {
+            else if (window != null && !(isShown ?? false)) {
                 Electron.IpcMain.Send(window, "show");
                 window.SetAlwaysOnTop(true, OnTopLevel.screenSaver);
                 isShown = true;
@@ -927,22 +793,18 @@ public class Startup
         };
     }
 
-    public static Task<Display[]> GetDisplays()
-    {
+    public static Task<Display[]> GetDisplays() {
         return Electron.Screen.GetAllDisplaysAsync();
     }
 
-    public static async Task<string?> GetMainWindowDisplay()
-    {
-        if (settings.Data.Contains("screenToUse"))
-        {
+    public static async Task<string?> GetMainWindowDisplay() {
+        if (settings.Data.Contains("screenToUse")) {
             return (string?)settings.Data.Get("screenToUse");
         }
         return (await Electron.Screen.GetPrimaryDisplayAsync()).Id;
     }
 
-    public static async Task<Display?> GetDisplayById(string id)
-    {
+    public static async Task<Display?> GetDisplayById(string id) {
         return Array.Find(await GetDisplays(), x => x.Id == id);
     }
 
@@ -950,13 +812,11 @@ public class Startup
     private bool recordingData = false;
     private double lastFuel = -1;
     private int lastLap = -1;
-    private void SaveData(R3E.Data.Shared data)
-    {
+    private void SaveData(R3E.Data.Shared data) {
         if (lastLap == -1 || lastLap == data.completedLaps || fuelData == null)
             return;
 
-        if (!recordingData)
-        {
+        if (!recordingData) {
             recordingData = true;
             lastFuel = data.fuelLeft;
             return;
@@ -971,8 +831,7 @@ public class Startup
         if (data.lapTimePreviousSelf > 0)
             combo.AddLapTime(data.lapTimePreviousSelf);
 
-        if (data.fuelUseActive >= 1 && lastFuel != -1)
-        {
+        if (data.fuelUseActive >= 1 && lastFuel != -1) {
             combo.AddFuelUsage(lastFuel - fuelNow, data.lapTimePreviousSelf > 0);
         }
 

--- a/Startup.cs
+++ b/Startup.cs
@@ -113,7 +113,7 @@ public class Startup
                             Electron.IpcMain.Send(window, "port", BridgeSettings.WebPort);
                         }
                     });
-                    await CreateMainWindow(env);
+                    await CreateMainWindow();
                     await CreateSettingsWindow(env);
 
                     await Task.Delay(1000); // TODO
@@ -155,7 +155,7 @@ public class Startup
         return await Electron.WindowManager.CreateWindowAsync(options, loadUrl);
     }
 
-    private async Task CreateMainWindow(IWebHostEnvironment env)
+    private async Task CreateMainWindow()
     {
         await Electron.IpcMain.On("used-keys", (args) => {
             if (args == null)
@@ -188,9 +188,6 @@ public class Startup
             Electron.App.Quit();
             return;
         }
-
-        //if (env.IsDevelopment())
-        //    MainWindow.WebContents.OpenDevTools();
 
         MainWindow.SetAlwaysOnTop(true, OnTopLevel.screenSaver);
         MainWindow.SetIgnoreMouseEvents(true);
@@ -407,8 +404,6 @@ public class Startup
 
         if (!env.IsDevelopment())
             SettingsWindow.RemoveMenu();
-        //else
-        //    SettingsWindow.WebContents.OpenDevTools();
 
         await Electron.IpcMain.On("restart-app", (args) =>
         {

--- a/Startup.cs
+++ b/Startup.cs
@@ -14,7 +14,7 @@ namespace ReHUD;
 
 public class Startup
 {
-    public static readonly ILog logger = LogManager.GetLogger(MethodBase.GetCurrentMethod()?.DeclaringType);
+    public static readonly ILog logger = LogManager.GetLogger(typeof(Startup));
     public static string? logFilePath;
 
     private IUpdateService updateService;
@@ -545,8 +545,7 @@ public class Startup
         }
     }
 
-    private static void EnableVRMode(bool enableVRMode)
-    {
+    private static void EnableVRMode(bool enableVRMode) {
         logger.Info("Setting main window background opacity: " + (enableVRMode ? "#FF" : "#00"));
         MainWindow?.SetBackgroundColor(enableVRMode ? BLACK_OPAQUE : BLACK_TRANSPARENT);
     }

--- a/Startup.cs
+++ b/Startup.cs
@@ -34,9 +34,6 @@ public class Startup
     // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
     public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
     {
-        //if (env.IsDevelopment())
-        //    Debugger.Launch();
-
         logFilePath = Path.Combine(JsonUserData.dataPath, "ReHUD.log");
         GlobalContext.Properties["LogFilePath"] = logFilePath;
 

--- a/Startup.cs
+++ b/Startup.cs
@@ -448,7 +448,7 @@ public class Startup
                     enteredEditMode = true;
                     IsInEditMode = true;
 
-                    if (!raceroomObserver.IsRunning)
+                    if (!sharedMemory.IsRunning)
                     {
                         var extraData = new ExtraData
                         {
@@ -469,7 +469,7 @@ public class Startup
                 isShown = null;
                 IsInEditMode = false;
 
-                if (!raceroomObserver.IsRunning)
+                if (!sharedMemory.IsRunning)
                 {
                     Electron.IpcMain.Send(MainWindow, "hide");
                 }

--- a/Utils/ProcessObserver.cs
+++ b/Utils/ProcessObserver.cs
@@ -1,9 +1,10 @@
-﻿using System.Diagnostics;
+﻿using ReHUD.Interfaces;
+using System.Diagnostics;
 using System.Management;
 
-namespace ReHUD
+namespace ReHUD.Utils
 {
-    public class ProcessObserver : IDisposable
+    public class ProcessObserver : IProcessObserver, IDisposable
     {
         private readonly List<string> processNames;
         private readonly ManagementEventWatcher startWatcher;
@@ -36,7 +37,7 @@ namespace ReHUD
         }
         private void ProcessStopped(object sender, EventArrivedEventArgs e)
         {
-            Startup.logger.Info($"Got process stop event for processes: {String.Join(", ", processNames)}");
+            Startup.logger.Info($"Got process stop event for processes: {string.Join(", ", processNames)}");
             OnProcessStopped?.Invoke();
         }
 

--- a/Utils/ProcessObserver.cs
+++ b/Utils/ProcessObserver.cs
@@ -1,4 +1,5 @@
-﻿using ReHUD.Interfaces;
+﻿using log4net;
+using ReHUD.Interfaces;
 using System.Diagnostics;
 using System.Management;
 
@@ -6,6 +7,8 @@ namespace ReHUD.Utils
 {
     public class ProcessObserver : IProcessObserver, IDisposable
     {
+        public static readonly ILog logger = LogManager.GetLogger(typeof(ProcessObserver));
+
         private readonly List<string> processNames;
         private readonly ManagementEventWatcher startWatcher;
         private readonly ManagementEventWatcher stopWatcher;
@@ -15,9 +18,8 @@ namespace ReHUD.Utils
 
         public bool IsRunning { get => processNames.Any(processName => Process.GetProcessesByName(processName).Length > 0); }
 
-        public ProcessObserver(List<string> processNames)
-        {
-            Startup.logger.Info($"Creating process observer for {processNames.Count} process names: {string.Join(", ", processNames)}");
+        public ProcessObserver(List<string> processNames) {
+            logger.Info($"Creating process observer for {processNames.Count} process names: {string.Join(", ", processNames)}");
 
             this.processNames = processNames;
 
@@ -30,46 +32,39 @@ namespace ReHUD.Utils
             stopWatcher.EventArrived += ProcessStopped;
         }
 
-        private void ProcessStarted(object sender, EventArrivedEventArgs e)
-        {
-            Startup.logger.Info($"Got process start event for processes: {string.Join(", ", processNames)}");
+        private void ProcessStarted(object sender, EventArrivedEventArgs e) {
+            logger.Info($"Got process start event for processes: {string.Join(", ", processNames)}");
             OnProcessStarted?.Invoke();
         }
-        private void ProcessStopped(object sender, EventArrivedEventArgs e)
-        {
-            Startup.logger.Info($"Got process stop event for processes: {string.Join(", ", processNames)}");
+        private void ProcessStopped(object sender, EventArrivedEventArgs e) {
+            logger.Info($"Got process stop event for processes: {string.Join(", ", processNames)}");
             OnProcessStopped?.Invoke();
         }
 
-        public void Start()
-        {
-            Startup.logger.Info("Start Called on Process Observer");
+        public void Start() {
+            logger.Info("Start Called on Process Observer");
 
             startWatcher.Start();
             stopWatcher.Start();
 
-            if (IsRunning)
-            {
-                Startup.logger.Info("Process is already running when Start called, emitting OnProcessStarted event");
+            if (IsRunning) {
+                logger.Info("Process is already running when Start called, emitting OnProcessStarted event");
                 OnProcessStarted?.Invoke();
             }
-            else
-            {
-                Startup.logger.Info("Process is not yet running when Start called, waiting for WMI event");
+            else {
+                logger.Info("Process is not yet running when Start called, waiting for WMI event");
             }
         }
 
-        public void Stop()
-        {
-            Startup.logger.Info("Stop Called on Process Observer");
+        public void Stop() {
+            logger.Info("Stop Called on Process Observer");
 
             startWatcher.Stop();
             stopWatcher.Stop();
         }
 
-        public void Dispose()
-        {
-            Startup.logger.Info("Disposing Process Observer");
+        public void Dispose() {
+            logger.Info("Disposing Process Observer");
 
             startWatcher.Stop();
             stopWatcher.Stop();

--- a/Utils/RaceRoomObserver.cs
+++ b/Utils/RaceRoomObserver.cs
@@ -1,0 +1,37 @@
+﻿using ReHUD.Interfaces;
+
+namespace ReHUD.Utils
+{
+    public class RaceRoomObserver : IRaceRoomObserver, IDisposable
+    {
+        private static readonly List<string> RaceRoomProcessNames = new() { "RRRE", "RRRE64" };
+
+        private IProcessObserver processObserver;
+
+        public event Action OnProcessStarted;
+        public event Action OnProcessStopped;
+
+        public bool IsRunning => processObserver.IsRunning;
+
+        public RaceRoomObserver(IProcessObserverFactory processObserverFactory) {
+            this.processObserver = processObserverFactory.GetObserver(RaceRoomProcessNames);
+
+            processObserver.OnProcessStarted += ProcessStarted;
+            processObserver.OnProcessStopped += ProcessStopped;
+        }
+
+        private void ProcessStarted() => OnProcessStarted?.Invoke();
+        private void ProcessStopped() => OnProcessStopped?.Invoke();
+
+        public void Start() => processObserver.Start();
+
+        public void Stop() => processObserver.Stop();
+
+        public void Dispose() {
+            processObserver.OnProcessStarted -= ProcessStarted;
+            processObserver.OnProcessStopped -= ProcessStopped;
+
+            processObserver.Dispose();
+        }
+    }
+}

--- a/Utils/Utilities.cs
+++ b/Utils/Utilities.cs
@@ -1,15 +1,17 @@
 using System.Diagnostics;
+using R3E.Data;
+using ReHUD.Models;
 
-namespace R3E
+namespace ReHUD.Utils
 {
     public static class Utilities
     {
-        public static Single RpsToRpm(Single rps)
+        public static float RpsToRpm(float rps)
         {
-            return rps * (60 / (2 * (Single)Math.PI));
+            return rps * (60 / (2 * (float)Math.PI));
         }
 
-        public static Single MpsToKph(Single mps)
+        public static float MpsToKph(float mps)
         {
             return mps * 3.6f;
         }
@@ -22,7 +24,7 @@ namespace R3E
         /// <summary>
         /// Returns either the estimated total number of laps and number of laps left, or null if the data is not available. <total, left>
         /// </summary>
-        internal static Tuple<int, double> GetEstimatedLapCount(Data.Shared data, ReHUD.FuelCombination combination)
+        internal static Tuple<int, double> GetEstimatedLapCount(R3eData data, FuelCombination combination)
         {
             double fraction = data.lapDistanceFraction;
 
@@ -30,10 +32,10 @@ namespace R3E
             double leaderCurrentLaptime = data.lapTimeCurrentSelf;
             int leaderCompletedLaps = data.completedLaps;
 
-            Data.DriverData? leader_ = GetLeader(data);
+            DriverData? leader_ = GetLeader(data);
             if (leader_ != null)
             {
-                Data.DriverData leader = leader_.Value;
+                DriverData leader = leader_.Value;
                 if (leader.finishStatus == 1)
                 {
                     return new Tuple<int, double>(data.completedLaps + 1, 1 - fraction);
@@ -53,7 +55,7 @@ namespace R3E
             }
 
 
-            if (leaderCompletedLaps == -1 || (leaderCompletedLaps == -1 && leaderFraction == -1))
+            if (leaderCompletedLaps == -1 || leaderCompletedLaps == -1 && leaderFraction == -1)
             {
                 return new Tuple<int, double>(-1, -1);
             }
@@ -114,9 +116,9 @@ namespace R3E
             return new Tuple<int, double>(res + data.completedLaps, res - fraction);
         }
 
-        internal static Data.DriverData? GetLeader(Data.Shared data)
+        internal static DriverData? GetLeader(R3eData data)
         {
-            foreach (Data.DriverData leader in data.driverData)
+            foreach (DriverData leader in data.driverData)
             {
                 if (leader.place == 1)
                 {

--- a/Utils/Utilities.cs
+++ b/Utils/Utilities.cs
@@ -1,31 +1,27 @@
-using System.Diagnostics;
 using R3E.Data;
 using ReHUD.Models;
+using System.Diagnostics;
 
 namespace ReHUD.Utils
 {
     public static class Utilities
     {
-        public static float RpsToRpm(float rps)
-        {
+        public static float RpsToRpm(float rps) {
             return rps * (60 / (2 * (float)Math.PI));
         }
 
-        public static float MpsToKph(float mps)
-        {
+        public static float MpsToKph(float mps) {
             return mps * 3.6f;
         }
 
-        public static bool IsRaceRoomRunning()
-        {
+        public static bool IsRaceRoomRunning() {
             return Process.GetProcessesByName("RRRE").Length > 0 || Process.GetProcessesByName("RRRE64").Length > 0;
         }
 
         /// <summary>
         /// Returns either the estimated total number of laps and number of laps left, or null if the data is not available. <total, left>
         /// </summary>
-        internal static Tuple<int, double> GetEstimatedLapCount(R3eData data, FuelCombination combination)
-        {
+        internal static Tuple<int, double> GetEstimatedLapCount(R3eData data, FuelCombination combination) {
             double fraction = data.lapDistanceFraction;
 
             double leaderFraction = fraction;
@@ -33,30 +29,25 @@ namespace ReHUD.Utils
             int leaderCompletedLaps = data.completedLaps;
 
             DriverData? leader_ = GetLeader(data);
-            if (leader_ != null)
-            {
+            if (leader_ != null) {
                 DriverData leader = leader_.Value;
-                if (leader.finishStatus == 1)
-                {
+                if (leader.finishStatus == 1) {
                     return new Tuple<int, double>(data.completedLaps + 1, 1 - fraction);
                 }
 
-                if (leader.completedLaps != -1)
-                {
+                if (leader.completedLaps != -1) {
                     leaderCompletedLaps = leader.completedLaps;
                 }
 
                 leaderCurrentLaptime = leader.lapTimeCurrentSelf;
                 leaderFraction = -1;
-                if (leader.lapDistance != -1 && data.layoutLength != -1)
-                {
+                if (leader.lapDistance != -1 && data.layoutLength != -1) {
                     leaderFraction = leader.lapDistance / data.layoutLength;
                 }
             }
 
 
-            if (leaderCompletedLaps == -1 || leaderCompletedLaps == -1 && leaderFraction == -1)
-            {
+            if (leaderCompletedLaps == -1 || leaderCompletedLaps == -1 && leaderFraction == -1) {
                 return new Tuple<int, double>(-1, -1);
             }
 
@@ -65,46 +56,36 @@ namespace ReHUD.Utils
             int res;
 
             double sessionTimeRemaining = data.sessionTimeRemaining;
-            if (sessionTimeRemaining != -1)
-            {
+            if (sessionTimeRemaining != -1) {
                 double referenceLap;
 
-                if (data.lapTimeBestLeader > 0 && leaderCompletedLaps > 1)
-                {
+                if (data.lapTimeBestLeader > 0 && leaderCompletedLaps > 1) {
                     referenceLap = data.lapTimeBestLeader;
                 }
-                else if (data.lapTimeBestSelf > 0 && data.completedLaps > 1)
-                {
+                else if (data.lapTimeBestSelf > 0 && data.completedLaps > 1) {
                     referenceLap = data.lapTimeBestSelf;
                 }
-                else
-                {
+                else {
                     referenceLap = combination.GetBestLapTime();
-                    if (referenceLap == -1)
-                    {
+                    if (referenceLap == -1) {
                         return new Tuple<int, double>(-1, -1);
                     }
                 }
 
-                if (leaderCurrentLaptime != -1)
-                {
+                if (leaderCurrentLaptime != -1) {
                     res = (int)Math.Ceiling((sessionTimeRemaining + leaderCurrentLaptime) / referenceLap);
                 }
-                else
-                {
+                else {
                     res = (int)Math.Ceiling(sessionTimeRemaining / referenceLap + leaderFraction);
                 }
             }
-            else
-            {
+            else {
                 int sessionLaps = data.numberOfLaps;
-                if (sessionLaps == -1)
-                {
+                if (sessionLaps == -1) {
                     return new Tuple<int, double>(-1, -1);
                 }
 
-                if (leaderCompletedLaps == -1)
-                {
+                if (leaderCompletedLaps == -1) {
                     return new Tuple<int, double>(sessionLaps, 0);
                 }
                 res = sessionLaps - leaderCompletedLaps;
@@ -116,12 +97,9 @@ namespace ReHUD.Utils
             return new Tuple<int, double>(res + data.completedLaps, res - fraction);
         }
 
-        internal static DriverData? GetLeader(R3eData data)
-        {
-            foreach (DriverData leader in data.driverData)
-            {
-                if (leader.place == 1)
-                {
+        internal static DriverData? GetLeader(R3eData data) {
+            foreach (DriverData leader in data.driverData) {
+                if (leader.place == 1) {
                     return leader;
                 }
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "source-map-js": "^1.0.2"
       },
       "devDependencies": {
+        "typescript": "^5.3.3",
         "webpack": "^5.88.2",
         "webpack-cli": "^5.1.4",
         "webpack-dev-server": "^4.15.1",
@@ -3776,6 +3777,19 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/universalify": {

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "webpack-node-externals": "^3.0.0"
   },
   "scripts": {
-    "prestart": ".\\node_modules\\.bin\\tsc --project tsconfig.json && webpack --devtool source-map --config webpack.config.js",
-    "start": "electronize start",
+    "prestart": "tsc && webpack --devtool source-map --config webpack.config.js",
+    "start": "electronize start  /args --inspect=9090",
     "build": "npm run prestart && electronize build /target win"
   },
   "type": "module"

--- a/package.json
+++ b/package.json
@@ -6,13 +6,14 @@
     "source-map-js": "^1.0.2"
   },
   "devDependencies": {
+    "typescript": "^5.3.3",
     "webpack": "^5.88.2",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^4.15.1",
     "webpack-node-externals": "^3.0.0"
   },
   "scripts": {
-    "prestart": "tsc && webpack --devtool source-map --config webpack.config.js",
+    "prestart": ".\\node_modules\\.bin\\tsc --project tsconfig.json && webpack --devtool source-map --config webpack.config.js",
     "start": "electronize start",
     "build": "npm run prestart && electronize build /target win"
   },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "prestart": "tsc && webpack --devtool source-map --config webpack.config.js",
-    "start": "electronize start  /args --inspect=9090",
+    "start": "electronize start /args --inspect=9090",
     "build": "npm run prestart && electronize build /target win"
   },
   "type": "module"

--- a/wwwroot/ts/Hud.ts
+++ b/wwwroot/ts/Hud.ts
@@ -5,7 +5,7 @@ import SettingsValue from "./SettingsValue.js";
 import DriverManager from "./actions/DriverManager.js";
 import RankedData from "./actions/RankedData.js";
 import TireManager from './actions/TireManager.js';
-import {SPEED_UNITS, PRESSURE_UNITS, RADAR_RANGE, DEFAULT_RADAR_RADIUS, IExtendedShared, RADAR_BEEP_VOLUME, RELATIVE_SAFE_MODE, POSITION_BAR_CELL_COUNT, DELTA_MODE, SHOW_DELTA_ON_INVALID_LAPS, FRAMERATE, HARDWARE_ACCELERATION} from "./consts.js";
+import {SPEED_UNITS, PRESSURE_UNITS, RADAR_RANGE, DEFAULT_RADAR_RADIUS, IExtendedShared, RADAR_BEEP_VOLUME, RELATIVE_SAFE_MODE, POSITION_BAR_CELL_COUNT, DELTA_MODE, SHOW_DELTA_ON_INVALID_LAPS, FRAMERATE, HARDWARE_ACCELERATION, ENABLE_VR_MODE} from "./consts.js";
 import IShared from './r3eTypes.js';
 import {AudioController, Logger} from "./utils.js";
 import {HudLayoutElements} from './settingsPage.js';
@@ -110,6 +110,7 @@ export default class Hud extends EventListener {
         new SettingsValue(SHOW_DELTA_ON_INVALID_LAPS, false);
         new SettingsValue(FRAMERATE, 60);
         new SettingsValue(HARDWARE_ACCELERATION, true);
+        new SettingsValue(ENABLE_VR_MODE, false);
 
         new EventEmitter('EventEmitter'); //TODO: currently this is needed to get the shared memory keys it's using, need to un-staticify it maybe
         SharedMemorySupplier.informBackend();

--- a/wwwroot/ts/consts.ts
+++ b/wwwroot/ts/consts.ts
@@ -29,6 +29,7 @@ export const SHOW_DELTA_ON_INVALID_LAPS = 'showDeltaOnInvalidLaps';
 export const FRAMERATE = 'framerate';
 export const HARDWARE_ACCELERATION = 'hardwareAcceleration';
 export const HUD_LAYOUT = 'hudLayout';
+export const ENABLE_VR_MODE = 'enableVRMode';
 
 export const DEFAULT_RENDER_CYCLE = 30;
 export const ITERATION_CYCLE = 1000;


### PR DESCRIPTION
Add ProcessObserver class to monitor for processes starting/stopping and file events.

Use RaceRoomProcessObserver in SharedMemory to start/stop the shared memory thread.

Optimize the shared memory threading and memory mapping to reduce mallocs and data copies.